### PR TITLE
Add support for object literals + object literal properties

### DIFF
--- a/src/parsing/binast-parser.h
+++ b/src/parsing/binast-parser.h
@@ -113,8 +113,8 @@ struct ParserTypes<BinAstParser> {
   using FunctionLiteral = v8::internal::BinAstFunctionLiteral*;
   using Identifier = const AstRawString*;
   using IterationStatement = v8::internal::BinAstIterationStatement*;
-  using ObjectLiteralProperty = ObjectLiteral::Property*;
-  using ObjectPropertyList = ScopedPtrList<v8::internal::ObjectLiteralProperty>;
+  using ObjectLiteralProperty = BinAstObjectLiteral::Property*;
+  using ObjectPropertyList = ScopedPtrList<v8::internal::BinAstObjectLiteralProperty>;
   using Statement = v8::internal::BinAstStatement*;
   using StatementList = ScopedPtrList<BinAstStatement>;
 
@@ -151,6 +151,13 @@ class BinAstParser : public ParserBase<BinAstParser> {
   {
     // TODO(binast)
     DCHECK(false);
+  }
+
+  ClassLiteralProperty* ParseClassPropertyDefinition(
+      ClassInfo* class_info, ParsePropertyInfo* prop_info, bool has_extends) {
+    // TODO(binast)
+    DCHECK(false);
+    return nullptr;
   }
 
   void ParseProgram(BinAstParseInfo* info);
@@ -754,11 +761,8 @@ class BinAstParser : public ParserBase<BinAstParser> {
     ZonePtrList<const AstRawString>* arguments_for_wrapped_function);
 
   BinAstObjectLiteral* InitializeObjectLiteral(BinAstObjectLiteral* object_literal) {
-    // object_literal->CalculateEmitStore(main_zone());
-    // return object_literal;
-    // TODO(binast)
-    DCHECK(false);
-    return nullptr;
+    object_literal->CalculateEmitStore(main_zone());
+    return object_literal;
   }
 
   // Producing data during the recursive descent.
@@ -862,7 +866,7 @@ class BinAstParser : public ParserBase<BinAstParser> {
   V8_INLINE ZonePtrList<BinAstExpression>* NewExpressionList(int size) const {
     return new (zone()) ZonePtrList<BinAstExpression>(size, zone());
   }
-  V8_INLINE ZonePtrList<ObjectLiteral::Property>* NewObjectPropertyList(
+  V8_INLINE ZonePtrList<BinAstObjectLiteral::Property>* NewObjectPropertyList(
       int size) const {
     // return new (zone()) ZonePtrList<ObjectLiteral::Property>(size, zone());
     // TODO(binast)
@@ -1070,20 +1074,50 @@ class BinAstParser : public ParserBase<BinAstParser> {
     return nullptr;
   }
 
-  void SetFunctionNameFromPropertyName(LiteralProperty* property,
+  void SetFunctionNameFromPropertyName(ClassLiteralProperty* property,
                                        const AstRawString* name,
-                                       const AstRawString* prefix = nullptr)
-  {
+                                       const AstRawString* prefix = nullptr) {
     // TODO(binast)
     DCHECK(false);
   }
 
-  void SetFunctionNameFromPropertyName(ObjectLiteralProperty* property,
+  void SetFunctionNameFromPropertyName(BinAstLiteralProperty* property,
+                                       const AstRawString* name,
+                                       const AstRawString* prefix = nullptr) {
+    if (has_error()) return;
+    // Ensure that the function we are going to create has shared name iff
+    // we are not going to set it later.
+    if (property->NeedsSetFunctionName()) {
+      name = nullptr;
+      prefix = nullptr;
+    } else {
+      // If the property value is an anonymous function or an anonymous class or
+      // a concise method or an accessor function which doesn't require the name
+      // to be set then the shared name must be provided.
+      DCHECK_IMPLIES(property->value()->IsAnonymousFunctionDefinition() ||
+                         property->value()->IsConciseMethodDefinition() ||
+                         property->value()->IsAccessorFunctionDefinition(),
+                     name != nullptr);
+    }
+
+    BinAstExpression* value = property->value();
+    SetFunctionName(value, name, prefix);
+  }
+
+  void SetFunctionNameFromPropertyName(BinAstObjectLiteralProperty* property,
                                        const AstRawString* name,
                                        const AstRawString* prefix = nullptr)
   {
-    // TODO(binast)
-    DCHECK(false);
+    // Ignore "__proto__" as a name when it's being used to set the [[Prototype]]
+    // of an object literal.
+    // See ES #sec-__proto__-property-names-in-object-initializers.
+    if (property->IsPrototype() || has_error()) return;
+
+    DCHECK(!property->value()->IsAnonymousFunctionDefinition() ||
+          property->kind() == ObjectLiteralProperty::COMPUTED);
+
+    SetFunctionNameFromPropertyName(static_cast<BinAstLiteralProperty*>(property), name,
+                                    prefix);
   }
 
   void SetFunctionNameFromIdentifierRef(BinAstExpression* value,
@@ -1446,11 +1480,8 @@ class BinAstParser : public ParserBase<BinAstParser> {
   }
 
   V8_INLINE static bool IsBoilerplateProperty(
-      ObjectLiteral::Property* property) {
-    // return !property->IsPrototype();
-    // TODO(binast)
-    DCHECK(false);
-    return false;
+      BinAstObjectLiteral::Property* property) {
+    return !property->IsPrototype();
   }
 
   V8_INLINE bool IsNative(BinAstExpression* expr) const {

--- a/src/parsing/binast-print-visitor.h
+++ b/src/parsing/binast-print-visitor.h
@@ -249,6 +249,34 @@ class BinAstPrintVisitor final : public BinAstVisitor {
     printf(")");
   }
 
+  virtual void VisitObjectLiteral(
+      BinAstObjectLiteral* object_literal) override {
+    PrintIndentLevel();
+    printf("ObjectLiteral(");
+    printf("{");
+    
+    auto properties = object_literal->properties();
+    for (int i = 0; i < properties->length(); i++) {
+      if (i == 0) {
+        printf("\n");
+        indent_level_++;
+      }
+      this->VisitNode(properties->at(i)->key());
+      printf(":\n");
+      indent_level_++;
+      this->VisitNode(properties->at(i)->value());
+      indent_level_--;
+      if (i < properties->length() - 1) {
+        printf(",\n");
+      } else {
+        printf("\n");
+        indent_level_--;
+        PrintIndentLevel();
+      }
+    }
+    printf("}");
+    printf(")");
+  }
 
  private:
   void PrintConsString(const AstConsString* s) {

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -37,6 +37,7 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   virtual void VisitProperty(BinAstProperty* property) override;
   virtual void VisitReturnStatement(BinAstReturnStatement* return_statement) override;
   virtual void VisitBinaryOperation(BinAstBinaryOperation* binary_op) override;
+  virtual void VisitObjectLiteral(BinAstObjectLiteral* binary_op) override;
 
  private:
   void SerializeUint32(uint32_t value);
@@ -172,6 +173,10 @@ void BinAstSerializeVisitor::VisitReturnStatement(BinAstReturnStatement* return_
 
 void BinAstSerializeVisitor::VisitBinaryOperation(BinAstBinaryOperation* binary_op) {
 
+}
+
+void BinAstSerializeVisitor::VisitObjectLiteral(BinAstObjectLiteral* object_literal) {
+  
 }
 
 

--- a/src/parsing/binast-visitor.h
+++ b/src/parsing/binast-visitor.h
@@ -27,6 +27,7 @@ public:
   virtual void VisitProperty(BinAstProperty* property) = 0;
   virtual void VisitReturnStatement(BinAstReturnStatement* return_statement) = 0;
   virtual void VisitBinaryOperation(BinAstBinaryOperation* binary_op) = 0;
+  virtual void VisitObjectLiteral(BinAstObjectLiteral* object_literal) = 0;
 
   void VisitNode(BinAstNode* node) {
     switch (node->node_type()) {
@@ -102,6 +103,11 @@ public:
 
       case BinAstNode::kBinaryOperation: {
         VisitBinaryOperation(static_cast<BinAstBinaryOperation*>(node));
+        break;
+      }
+
+      case BinAstNode::kObjectLiteral: {
+        VisitObjectLiteral(static_cast<BinAstObjectLiteral*>(node));
         break;
       }
 

--- a/src/parsing/binast.cc
+++ b/src/parsing/binast.cc
@@ -79,6 +79,14 @@ BinAstIterationStatement* BinAstNode::AsIterationStatement() {
   }
 }
 
+MaterializedLiteral* BinAstNode::AsMaterializedLiteral() {
+  switch (node_type()) {
+    // TODO(binast): materialized literals might not be needed for binast and have not been implemented
+    default:
+      return nullptr;
+  }
+}
+
 bool BinAstExpression::IsPropertyName() const {
   return IsLiteral() && AsLiteral()->IsPropertyName();
 }
@@ -105,6 +113,10 @@ bool BinAstExpression::IsAccessorFunctionDefinition() const {
 
 bool BinAstExpression::IsNumberLiteral() const {
   return IsLiteral() && AsLiteral()->IsNumber();
+}
+
+bool BinAstExpression::IsNullLiteral() const {
+  return IsLiteral() && AsLiteral()->type() == BinAstLiteral::kNull;
 }
 
 bool BinAstExpression::IsTheHoleLiteral() const {
@@ -138,6 +150,85 @@ void BinAstFunctionLiteral::set_raw_inferred_name(AstConsString* raw_inferred_na
   raw_inferred_name_ = raw_inferred_name;
   scope()->set_has_inferred_function_name(true);
 }
+
+void BinAstObjectLiteral::CalculateEmitStore(Zone* zone) {
+  const auto GETTER = ObjectLiteralProperty::GETTER;
+  const auto SETTER = ObjectLiteralProperty::SETTER;
+
+  ZoneAllocationPolicy allocator(zone);
+
+  CustomMatcherZoneHashMap table(
+      BinAstLiteral::Match, ZoneHashMap::kDefaultHashMapCapacity, allocator);
+  for (int i = properties()->length() - 1; i >= 0; i--) {
+    BinAstObjectLiteralProperty* property = properties()->at(i);
+    if (property->is_computed_name()) continue;
+    if (property->IsPrototype()) continue;
+    BinAstLiteral* literal = property->key()->AsLiteral();
+    DCHECK(!literal->IsNullLiteral());
+
+    uint32_t hash = literal->Hash();
+    ZoneHashMap::Entry* entry = table.LookupOrInsert(literal, hash, allocator);
+    if (entry->value == nullptr) {
+      entry->value = property;
+    } else {
+      // We already have a later definition of this property, so we don't need
+      // to emit a store for the current one.
+      //
+      // There are two subtleties here.
+      //
+      // (1) Emitting a store might actually be incorrect. For example, in {get
+      // foo() {}, foo: 42}, the getter store would override the data property
+      // (which, being a non-computed compile-time valued property, is already
+      // part of the initial literal object.
+      //
+      // (2) If the later definition is an accessor (say, a getter), and the
+      // current definition is a complementary accessor (here, a setter), then
+      // we still must emit a store for the current definition.
+
+      auto later_kind =
+          static_cast<BinAstObjectLiteral::Property*>(entry->value)->kind();
+      bool complementary_accessors =
+          (property->kind() == GETTER && later_kind == SETTER) ||
+          (property->kind() == SETTER && later_kind == GETTER);
+      if (!complementary_accessors) {
+        property->set_emit_store(false);
+        if (later_kind == GETTER || later_kind == SETTER) {
+          entry->value = property;
+        }
+      }
+    }
+  }
+}
+
+BinAstObjectLiteralProperty::BinAstObjectLiteralProperty(BinAstExpression* key, BinAstExpression* value,
+                                             ObjectLiteralProperty::Kind kind, bool is_computed_name)
+    : BinAstLiteralProperty(key, value, is_computed_name),
+      kind_(kind),
+      emit_store_(true) {}
+
+BinAstObjectLiteralProperty::BinAstObjectLiteralProperty(BinAstValueFactory* ast_value_factory,
+                                             BinAstExpression* key, BinAstExpression* value,
+                                             bool is_computed_name)
+    : BinAstLiteralProperty(key, value, is_computed_name), emit_store_(true) {
+  if (!is_computed_name && key->AsLiteral()->IsString() &&
+      key->AsLiteral()->AsRawString() == ast_value_factory->proto_string()) {
+    kind_ = ObjectLiteralProperty::PROTOTYPE;
+  } else if (value_->AsMaterializedLiteral() != nullptr) {
+    // TODO(binast): materialized literals might not be needed for binast and have not been implemented
+    DCHECK(false);
+    // kind_ = ObjectLiteralProperty::MATERIALIZED_LITERAL;
+  } else if (value_->IsLiteral()) {
+    kind_ = ObjectLiteralProperty::CONSTANT;
+  } else {
+    kind_ = ObjectLiteralProperty::COMPUTED;
+  }
+}
+
+void BinAstObjectLiteralProperty::set_emit_store(bool emit_store) {
+  emit_store_ = emit_store;
+}
+
+bool BinAstObjectLiteralProperty::emit_store() const { return emit_store_; }
 
 }  // namespace internal
 }  // namespace v8

--- a/src/parsing/binast.h
+++ b/src/parsing/binast.h
@@ -141,7 +141,7 @@ class BinAstNode : public ZoneObject {
   int position() const { return position_; }
 
   BinAstIterationStatement* AsIterationStatement();
-  // MaterializedLiteral* AsMaterializedLiteral();
+  MaterializedLiteral* AsMaterializedLiteral();
 
  private:
   // Hidden to prevent accidental usage. It would have to load the
@@ -243,11 +243,7 @@ class BinAstExpression : public BinAstNode {
   }
 
   // True iff the expression is the null literal.
-  bool IsNullLiteral() const {
-    // TODO(binast)
-    DCHECK(false);
-    return false;
-  }
+  bool IsNullLiteral() const;
 
   // True iff the expression is the hole literal.
   bool IsTheHoleLiteral() const;
@@ -1168,11 +1164,22 @@ class BinAstLiteral final : public BinAstExpression {
   // template <typename LocalIsolate>
   // Handle<Object> BuildValue(LocalIsolate* isolate) const;
 
-  // TODO(binast)
   // Support for using Literal as a HashMap key. NOTE: Currently, this works
   // only for string and number literals!
-  // uint32_t Hash();
-  // static bool Match(void* literal1, void* literal2);
+  uint32_t Hash() {
+    return IsString() ? AsRawString()->Hash()
+                      : ComputeLongHash(double_to_uint64(AsNumber()));
+  }
+
+  // static
+  static bool Match(void* a, void* b) {
+    BinAstLiteral* x = static_cast<BinAstLiteral*>(a);
+    BinAstLiteral* y = static_cast<BinAstLiteral*>(b);
+    return (x->IsString() && y->IsString() &&
+            x->AsRawString() == y->AsRawString()) ||
+          (x->IsNumber() && y->IsNumber() && x->AsNumber() == y->AsNumber());
+  }
+
 
 
  private:
@@ -1367,12 +1374,60 @@ class BinAstThisExpression final : public BinAstExpression {
   BinAstThisExpression() : BinAstExpression(kNoSourcePosition, kThisExpression) {}
 };
 
+// Common supertype for ObjectLiteralProperty and ClassLiteralProperty
+class BinAstLiteralProperty : public ZoneObject {
+ public:
+  BinAstExpression* key() const { return key_and_is_computed_name_.GetPointer(); }
+  BinAstExpression* value() const { return value_; }
+
+  bool is_computed_name() const {
+    return key_and_is_computed_name_.GetPayload();
+  }
+  bool NeedsSetFunctionName() const {
+    return is_computed_name() && (value_->IsAnonymousFunctionDefinition() ||
+                                  value_->IsConciseMethodDefinition() ||
+                                  value_->IsAccessorFunctionDefinition());
+  }
+
+ protected:
+  BinAstLiteralProperty(BinAstExpression* key, BinAstExpression* value, bool is_computed_name)
+      : key_and_is_computed_name_(key, is_computed_name), value_(value) {}
+
+  PointerWithPayload<BinAstExpression, bool, 1> key_and_is_computed_name_;
+  BinAstExpression* value_;
+};
+
+class BinAstObjectLiteralProperty final : public BinAstLiteralProperty {
+ public:
+  ObjectLiteralProperty::Kind kind() const { return kind_; }
+
+  bool IsCompileTimeValue() const;
+
+  void set_emit_store(bool emit_store);
+  bool emit_store() const;
+
+  bool IsNullPrototype() const {
+    return IsPrototype() && value()->IsNullLiteral();
+  }
+  bool IsPrototype() const { return kind() == ObjectLiteralProperty::PROTOTYPE; }
+
+ private:
+  friend class BinAstNodeFactory;
+
+  BinAstObjectLiteralProperty(BinAstExpression* key, BinAstExpression* value, ObjectLiteralProperty::Kind kind,
+                        bool is_computed_name);
+  BinAstObjectLiteralProperty(BinAstValueFactory* ast_value_factory, BinAstExpression* key,
+                        BinAstExpression* value, bool is_computed_name);
+
+  ObjectLiteralProperty::Kind kind_;
+  bool emit_store_;
+};
 
 // An object literal has a boilerplate object that is used
 // for minimizing the work when constructing it at runtime.
 class BinAstObjectLiteral final : public BinAstAggregateLiteral {
  public:
-  using Property = ObjectLiteralProperty;
+  using Property = BinAstObjectLiteralProperty;
 
   // Handle<ObjectBoilerplateDescription> boilerplate_description() const {
   //   DCHECK(!boilerplate_description_.is_null());
@@ -2359,33 +2414,23 @@ class BinAstNodeFactory final {
   }
 
   BinAstObjectLiteral* NewObjectLiteral(
-      const ScopedPtrList<ObjectLiteral::Property>& properties,
+      const ScopedPtrList<BinAstObjectLiteral::Property>& properties,
       uint32_t boilerplate_properties, int pos, bool has_rest_property) {
-    // return new (zone_) ObjectLiteral(zone_, properties, boilerplate_properties,
-    //                                  pos, has_rest_property);
-    // TODO(binast)
-    DCHECK(false);
-    return nullptr;
+    return new (zone_) BinAstObjectLiteral(zone_, properties, boilerplate_properties, pos, has_rest_property);
   }
 
-  ObjectLiteral::Property* NewObjectLiteralProperty(
+  BinAstObjectLiteral::Property* NewObjectLiteralProperty(
       BinAstExpression* key, BinAstExpression* value, ObjectLiteralProperty::Kind kind,
       bool is_computed_name) {
-    // return new (zone_)
-    //     ObjectLiteral::Property(key, value, kind, is_computed_name);
-    // TODO(binast)
-    DCHECK(false);
-    return nullptr;
+    return new (zone_)
+        BinAstObjectLiteral::Property(key, value, kind, is_computed_name);
   }
 
-  ObjectLiteral::Property* NewObjectLiteralProperty(BinAstExpression* key,
+  BinAstObjectLiteral::Property* NewObjectLiteralProperty(BinAstExpression* key,
                                                     BinAstExpression* value,
                                                     bool is_computed_name) {
-    // return new (zone_) ObjectLiteral::Property(ast_value_factory_, key, value,
-    //                                            is_computed_name);
-    // TODO(binast)
-    DCHECK(false);
-    return nullptr;
+    return new (zone_) BinAstObjectLiteral::Property(ast_value_factory_, key, value,
+                                               is_computed_name);
   }
 
   BinAstRegExpLiteral* NewRegExpLiteral(const AstRawString* pattern, int flags,

--- a/src/parsing/test_binast.cc
+++ b/src/parsing/test_binast.cc
@@ -16,6 +16,8 @@ static const char* test_scripts[] = {
   "'use strict';\nvar sum = 0;\nfor (var i = 0; i < 10; ++i) {\n  sum += i;\n}\nconsole.log(sum);",
   "'use strict';\nvar square = function(x) { return x * x; };\nconsole.log('square(3) =', square(3));",
   "'use strict';\nfunction square(x) { return x * x; }\nconsole.log('square(5) =', square(5));",
+  "'use strict';\nvar obj = {};",
+  "'use strict';\nvar obj = {foo: 'bar', bar: 1, baz: function(x) { return x; }};",
 };
 
 static const size_t num_test_scripts = sizeof(test_scripts) / sizeof(char*);


### PR DESCRIPTION
example test output:

```
Script #7
'use strict';
var obj = {};

Creating BinAstParseInfo...Done!
Creating BinAstParser...Done!
Parsing program...Done!
Dumping AST...
BinAstFunctionLiteral("", 
  ExpressionStatement(
    Literal("use strict")
  ),
  BinAstBlock(
    ExpressionStatement(
      Assignment(
        op:INIT,
        VariableProxyExpression(obj)
        ObjectLiteral({})
      )
    ),
  )
)

Script #8
'use strict';
var obj = {foo: 'bar', bar: 1, baz: function(x) { return x; }};

Creating BinAstParseInfo...Done!
Creating BinAstParser...Done!
Parsing program...Done!
Dumping AST...
BinAstFunctionLiteral("", 
  ExpressionStatement(
    Literal("use strict")
  ),
  BinAstBlock(
    ExpressionStatement(
      Assignment(
        op:INIT,
        VariableProxyExpression(obj)
        ObjectLiteral({
          Literal("foo"):
            Literal("bar"),
          Literal("bar"):
            Literal(Smi:1.000000),
          Literal("baz"):
            BinAstFunctionLiteral("baz", 
              ReturnStatement(
                VariableProxyExpression(x)
              )
            )
        })
      )
    ),
  )
)
```