### PR TITLE
Add serialization support for AstConsStrings

### DIFF
--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -17,7 +17,7 @@ BinAstDeserializer::BinAstDeserializer(Parser* parser)
 
 }
 
-uint32_t BinAstDeserializer::DeserializeUint32(ByteArray bytes, int offset) {
+BinAstDeserializer::DeserializeResult<uint32_t> BinAstDeserializer::DeserializeUint32(ByteArray bytes, int offset) {
   uint32_t result = 0;
   for (int i = 0; i < 4; ++i) {
     size_t shift = sizeof(uint8_t) * 8 * i;
@@ -25,10 +25,10 @@ uint32_t BinAstDeserializer::DeserializeUint32(ByteArray bytes, int offset) {
     uint32_t shifted_value = unshifted_value << shift;
     result |= shifted_value;
   }
-  return result;
+  return {result, offset + sizeof(uint32_t)};
 }
 
-int32_t BinAstDeserializer::DeserializeInt32(ByteArray bytes, int offset) {
+BinAstDeserializer::DeserializeResult<int32_t> BinAstDeserializer::DeserializeInt32(ByteArray bytes, int offset) {
   uint32_t result = 0;
   for (int i = 0; i < 4; ++i) {
     size_t shift = sizeof(uint8_t) * 8 * i;
@@ -36,55 +36,101 @@ int32_t BinAstDeserializer::DeserializeInt32(ByteArray bytes, int offset) {
     uint32_t shifted_value = unshifted_value << shift;
     result |= shifted_value;
   }
-  return result;
+  return {result, offset + sizeof(int32_t)};
 }
 
-uint8_t BinAstDeserializer::DeserializeUint8(ByteArray bytes, int offset) {
-  return bytes.get(offset);
+BinAstDeserializer::DeserializeResult<uint8_t> BinAstDeserializer::DeserializeUint8(ByteArray bytes, int offset) {
+  return {bytes.get(offset), offset + sizeof(uint8_t)};
 }
 
-int BinAstDeserializer::DeserializeString(ByteArray serialized_ast, int offset) {
-  bool is_one_byte = DeserializeUint8(serialized_ast, offset);
-  uint32_t hash_field = DeserializeUint32(serialized_ast, offset + 1);
-  uint32_t length = DeserializeUint32(serialized_ast, offset + 1 + 4);
+BinAstDeserializer::DeserializeResult<const AstRawString*> BinAstDeserializer::DeserializeRawString(ByteArray serialized_ast, int offset) {
+  auto is_one_byte = DeserializeUint8(serialized_ast, offset);
+  offset = is_one_byte.new_offset;
+
+  auto hash_field = DeserializeUint32(serialized_ast, offset);
+  offset = hash_field.new_offset;
+
+  auto length = DeserializeUint32(serialized_ast, offset);
+  offset = length.new_offset;
+
   std::vector<uint8_t> raw_data;
-  for (uint32_t i = 0; i < length; ++i) {
-    int index = offset + 1 + 4 + 4 + i;
-    raw_data.push_back(DeserializeUint8(serialized_ast, index));
+  for (uint32_t i = 0; i < length.value; ++i) {
+    auto next_byte = DeserializeUint8(serialized_ast, offset);
+    offset = next_byte.new_offset;
+    raw_data.push_back(next_byte.value);
   }
   const AstRawString* s = nullptr;
   if (raw_data.size() > 0) {
     Vector<const byte> literal_bytes(&raw_data[0], raw_data.size());
-    s = parser_->ast_value_factory()->GetString(hash_field, is_one_byte, literal_bytes);
+    s = parser_->ast_value_factory()->GetString(hash_field.value, is_one_byte.value, literal_bytes);
   } else {
     Vector<const byte> literal_bytes;
-    s = parser_->ast_value_factory()->GetString(hash_field, is_one_byte, literal_bytes);
+    s = parser_->ast_value_factory()->GetString(hash_field.value, is_one_byte.value, literal_bytes);
   }
-  string_table_.insert({string_table_.size(), s});
-  return offset + 1 + 4 + 4 + length;
+  string_table_.insert({string_table_.size() + 1, s});
+  return {s, offset};
 }
 
-int BinAstDeserializer::DeserializeStringTable(ByteArray serialized_ast, int offset) {
-  uint32_t num_entries = DeserializeUint32(serialized_ast, offset);
-  offset += 4;
-  for (uint32_t i = 0; i < num_entries; ++i) {
-    offset = DeserializeString(serialized_ast, offset);
+BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::DeserializeStringTable(ByteArray serialized_ast, int offset) {
+  auto num_entries = DeserializeUint32(serialized_ast, offset);
+  offset = num_entries.new_offset;
+  for (uint32_t i = 0; i < num_entries.value; ++i) {
+    auto string = DeserializeRawString(serialized_ast, offset);
+    offset = string.new_offset;
   }
-  return offset;
+  return {nullptr, offset};
+}
+
+BinAstDeserializer::DeserializeResult<const AstRawString*> BinAstDeserializer::DeserializeRawStringReference(ByteArray serialized_ast, int offset) {
+  auto string_table_index = DeserializeUint32(serialized_ast, offset);
+  offset = string_table_index.new_offset;
+  auto lookup_result = string_table_.find(string_table_index.value);
+  DCHECK(lookup_result != string_table_.end());
+  const AstRawString* result = lookup_result->second;
+  DCHECK(result != nullptr);
+  return {result, offset};
+}
+
+BinAstDeserializer::DeserializeResult<AstConsString*> BinAstDeserializer::DeserializeConsString(ByteArray serialized_ast, int offset) {
+  auto raw_string_count = DeserializeUint32(serialized_ast, offset);
+  offset = raw_string_count.new_offset;
+
+  if (raw_string_count.value == 0) {
+    return {nullptr, offset};
+  }
+
+  AstConsString* cons_string = parser_->ast_value_factory()->NewConsString();
+
+  for (uint32_t i = 0; i < raw_string_count.value; ++i) {
+    auto string = DeserializeRawStringReference(serialized_ast, offset);
+    DCHECK(parser_->zone() != nullptr);
+    cons_string->AddString(parser_->zone(), string.value);
+    offset = string.new_offset;
+  }
+
+  return {cons_string, offset};
 }
 
 AstNode* BinAstDeserializer::DeserializeAst(ByteArray serialized_ast) {
   int offset = 0;
-  offset = DeserializeStringTable(serialized_ast, offset);
-  return DeserializeAstNode(serialized_ast, offset);
+  auto result = DeserializeStringTable(serialized_ast, offset);
+  offset = result.new_offset;
+  auto result = DeserializeAstNode(serialized_ast, offset);
+  return result.value;
 }
 
-AstNode* BinAstDeserializer::DeserializeAstNode(ByteArray serialized_binast, int offset) {
-  uint32_t bit_field = DeserializeUint32(serialized_binast, offset);
-  AstNode::NodeType nodeType = AstNode::NodeTypeField::decode(bit_field);
+BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::DeserializeAstNode(ByteArray serialized_binast, int offset) {
+  auto bit_field = DeserializeUint32(serialized_binast, offset);
+  offset = bit_field.new_offset;
+
+  auto position = DeserializeInt32(serialized_binast, offset);
+  offset = position.new_offset;
+
+  AstNode::NodeType nodeType = AstNode::NodeTypeField::decode(bit_field.value);
   switch (nodeType) {
   case AstNode::kFunctionLiteral: {
-    return DeserializeFunctionLiteral(serialized_binast, bit_field, offset);
+    auto result = DeserializeFunctionLiteral(serialized_binast, bit_field.value, position.value, offset);
+    return {result.value, result.new_offset};
   }
   default: {
     UNREACHABLE();
@@ -92,10 +138,24 @@ AstNode* BinAstDeserializer::DeserializeAstNode(ByteArray serialized_binast, int
   }
 }
 
-FunctionLiteral* BinAstDeserializer::DeserializeFunctionLiteral(ByteArray serialized_binast, uint32_t bit_field, int offset) {
-  int32_t position = DeserializeInt32(serialized_binast, offset + sizeof(bit_field));
+BinAstDeserializer::DeserializeResult<FunctionLiteral*> BinAstDeserializer::DeserializeFunctionLiteral(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset) {
   std::vector<void*> pointer_buffer;
-  /* TODO */const AstRawString* name = nullptr;
+  // TODO(binast): Kind of silly that we serialize a cons string only to deserialized into a raw string
+  auto name = DeserializeConsString(serialized_binast, offset);
+  offset = name.new_offset;
+
+  const AstRawString* raw_name = nullptr;
+  if (name.value == nullptr) {
+    raw_name = nullptr;
+  } else {
+    for (const AstRawString* s : name.value->ToRawStrings()) {
+      DCHECK(raw_name == nullptr);
+      DCHECK(s != nullptr);
+      raw_name = s;
+    }
+    DCHECK(raw_name != nullptr);
+  }
+  
   /* TODO */DeclarationScope* scope = nullptr;
   /* TODO */const ScopedPtrList<Statement> body(&pointer_buffer);
   /* TODO */int expected_property_count = 0;
@@ -107,7 +167,7 @@ FunctionLiteral* BinAstDeserializer::DeserializeFunctionLiteral(ByteArray serial
   /* TODO */bool has_braces = false;
   /* TODO */int function_literal_id = 0;
   FunctionLiteral* result = parser_->factory()->NewFunctionLiteral(
-    name, scope, body, expected_property_count, parameter_count, 
+    raw_name, scope, body, expected_property_count, parameter_count, 
     function_length, has_duplicate_parameters, function_syntax_kind,
     eager_compile_hint, position, has_braces, function_literal_id);
   return result;

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -16,6 +16,7 @@ class ByteArray;
 class FunctionLiteral;
 class ParseInfo;
 class Parser;
+class AstConsString;
 class AstRawString;
 
 class BinAstDeserializer {
@@ -25,15 +26,23 @@ class BinAstDeserializer {
   AstNode* DeserializeAst(ByteArray serialized_ast);
 
  private:
-  uint32_t DeserializeUint32(ByteArray bytes, int offset);
-  int32_t DeserializeInt32(ByteArray bytes, int offset);
-  uint8_t DeserializeUint8(ByteArray bytes, int offset);
+  template <typename T>
+  struct DeserializeResult {
+    T value;
+    int new_offset;
+  };
 
-  int DeserializeString(ByteArray bytes, int offset);
-  int DeserializeStringTable(ByteArray bytes, int offset);
+  DeserializeResult<uint32_t> DeserializeUint32(ByteArray bytes, int offset);
+  DeserializeResult<int32_t> DeserializeInt32(ByteArray bytes, int offset);
+  DeserializeResult<uint8_t> DeserializeUint8(ByteArray bytes, int offset);
 
-  AstNode* DeserializeAstNode(ByteArray serialized_ast, int offset);
-  FunctionLiteral* DeserializeFunctionLiteral(ByteArray serialized_ast, uint32_t bit_field, int offset);
+  DeserializeResult<const AstRawString*> DeserializeRawString(ByteArray bytes, int offset);
+  DeserializeResult<std::nullptr_t> DeserializeStringTable(ByteArray bytes, int offset);
+  DeserializeResult<const AstRawString*> DeserializeRawStringReference(ByteArray bytes, int offset);
+  DeserializeResult<AstConsString*> DeserializeConsString(ByteArray bytes, int offset);
+
+  DeserializeResult<AstNode*> DeserializeAstNode(ByteArray serialized_ast, int offset);
+  DeserializeResult<FunctionLiteral*> DeserializeFunctionLiteral(ByteArray serialized_ast, uint32_t bit_field, int32_t position, int offset);
 
   Parser* parser_;
   std::unordered_map<uint32_t, const AstRawString*> string_table_;

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -6,6 +6,7 @@
 #define V8_PARSING_BINAST_SERIALIZE_VISITOR_H_
 
 #include "src/parsing/binast-visitor.h"
+#include <mutex>
 
 namespace v8 {
 namespace internal {
@@ -43,8 +44,10 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   void SerializeUint32(uint32_t value);
   void SerializeInt32(int32_t value);
   void SerializeUint8(uint8_t value);
-  void SerializeString(const AstRawString* s);
-  void SerializeStringTable();
+  void SerializeRawString(const AstRawString* s);
+  void SerializeConsString(const AstConsString* cons_string);
+  void SerializeRawStringReference(const AstRawString* s);
+  void SerializeStringTable(const AstConsString* function_name);
 
   BinAstValueFactory* ast_value_factory_;
   std::unordered_map<const AstRawString*, uint32_t> string_table_indices_;
@@ -79,8 +82,9 @@ inline void BinAstSerializeVisitor::SerializeUint8(uint8_t value) {
   byte_data_.push_back(value);
 }
 
-void BinAstSerializeVisitor::SerializeString(const AstRawString* s) {
+void BinAstSerializeVisitor::SerializeRawString(const AstRawString* s) {
   DCHECK(s != nullptr);
+  DCHECK(string_table_indices_.count(s) == 0);
   uint32_t length = s->byte_length();
   bool is_one_byte = s->is_one_byte();
   uint32_t hash_field = s->hash_field();
@@ -96,27 +100,81 @@ void BinAstSerializeVisitor::SerializeString(const AstRawString* s) {
   }
 }
 
-void BinAstSerializeVisitor::SerializeStringTable() {
+void BinAstSerializeVisitor::SerializeRawStringReference(const AstRawString* s) {
+  auto lookup_result = string_table_indices_.find(s);
+  DCHECK(lookup_result != string_table_indices_.end());
+  uint32_t string_table_index = lookup_result->second;
+  SerializeUint32(string_table_index);
+}
+
+void BinAstSerializeVisitor::SerializeConsString(const AstConsString* cons_string) {
+  if (cons_string == nullptr) {
+    // TODO(binast): This makes it impossible to distinguish between a nullptr and an empty AstConsString. Not sure if it will matter...
+    SerializeUint32(0);
+    return;
+  }
+  std::forward_list<const AstRawString*> strings = cons_string->ToRawStrings();
+  uint32_t length = 0;
+  for (const AstRawString* string : strings) {
+    DCHECK(string != nullptr);
+    DCHECK(string_table_indices_.count(string) == 1);
+    length += 1;
+  }
+
+  SerializeUint32(length);
+  for (const AstRawString* string : strings) {
+    DCHECK(string != nullptr);
+    SerializeRawStringReference(string);
+  }
+}
+
+void BinAstSerializeVisitor::SerializeStringTable(const AstConsString* function_name) {
   uint32_t num_entries = ast_value_factory_->string_table_.occupancy();
+  // We serialize the outer function raw_name too.
+  // TODO(binast): Do we need to?
+  if (function_name != nullptr) {
+    for (const AstRawString* s : function_name->ToRawStrings()) {
+      DCHECK(s != nullptr);
+      (void)s;
+      num_entries += 1;
+    }
+  }
   SerializeUint32(num_entries);
-  uint32_t current_index = 0;
+  uint32_t current_index = 1;
   for (base::HashMap::Entry* entry = ast_value_factory_->string_table_.Start(); entry != nullptr; entry = ast_value_factory_->string_table_.Next(entry)) {
     const AstRawString* s = reinterpret_cast<const AstRawString*>(entry->key);
+    SerializeRawString(s);
     string_table_indices_.insert({s, current_index});
-    SerializeString(s);
     current_index += 1;
   }
-  DCHECK(current_index == num_entries);
+
+  if (function_name != nullptr) {
+    for (const AstRawString* s : function_name->ToRawStrings()) {
+      SerializeRawString(s);
+      string_table_indices_.insert({s, current_index});
+      current_index += 1;
+    }
+  }
+
+  DCHECK(current_index == num_entries + 1);
 }
 
 void BinAstSerializeVisitor::SerializeAst(BinAstNode* root) {
-  SerializeStringTable();
+  // TODO(binast): Remove (they currently make output slightly easier to read)
+  static std::mutex global_lock;
+  std::lock_guard<std::mutex> lock(global_lock);
+
+  BinAstFunctionLiteral* literal = root->AsFunctionLiteral();
+  DCHECK(literal != nullptr);
+  SerializeStringTable(literal->raw_name());
   VisitNode(root);
 }
 
 void BinAstSerializeVisitor::VisitFunctionLiteral(BinAstFunctionLiteral* function_literal) {
   SerializeUint32(function_literal->bit_field_);
   SerializeInt32(function_literal->position_);
+  const AstConsString* name = function_literal->raw_name();
+  SerializeConsString(name);
 }
 
 void BinAstSerializeVisitor::VisitBlock(BinAstBlock* block) {

--- a/src/parsing/parsing.cc
+++ b/src/parsing/parsing.cc
@@ -92,7 +92,7 @@ bool ParseFunction(ParseInfo* info, Handle<SharedFunctionInfo> shared_info,
 
   if (shared_info->HasUncompiledDataWithBinAstParseData()) {
     // TODO(binast): Actually deserialize the AST, store it on the ParseInfo, and skip normal parsing.
-    // printf("Saw a SFI with bin AST parse data!\n");
+    auto start = std::chrono::high_resolution_clock::now();
     Handle<BinAstParseData> binast_parse_data = handle(shared_info->uncompiled_data_with_binast_parse_data().binast_parse_data(), isolate);
     // TODO(binast): Probably hide all this stuff inside the parsing module
     BinAstDeserializer deserializer(&parser);
@@ -100,7 +100,9 @@ bool ParseFunction(ParseInfo* info, Handle<SharedFunctionInfo> shared_info,
     DCHECK(ast_node->node_type() == AstNode::NodeType::kFunctionLiteral);
     FunctionLiteral* literal = ast_node->AsFunctionLiteral();
     DCHECK(literal != nullptr);
-    // printf("Deserialized function literal: %p\n", literal);
+    auto elapsed = std::chrono::high_resolution_clock::now() - start;
+    long long microseconds = std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
+    printf("Deserialized function literal in %lld us: %p\n", microseconds, literal);
     // TODO(binast): Store the literal on the ParseInfo
   }
 

--- a/test/binast/test.js
+++ b/test/binast/test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var double = function(x) { return x * 2; }
+function triple(x) { return x * 3; }
+
+var oldSetTimeout = setTimeout;
+var timerCallbacks = [];
+function newSetTimeout(func, delayMs) {
+  var deadline = new Date();
+  deadline.setTime(deadline.getTime() + delayMs)
+  var newCallback = new Object();
+  newCallback.cb = func;
+  newCallback.deadline = deadline;
+  timerCallbacks.push(newCallback);
+  // Reverse sort so back of the array has the nearest timer callbacks
+  timerCallbacks.sort(function(e1, e2) {
+    return e2.deadline - e1.deadline;
+  });
+};
+setTimeout = newSetTimeout;
+
+function tickRunLoop(nextDeadline) {
+  oldSetTimeout(function() {
+    // We don't currently have a deadline, so look for the next timer callback to find a new deadline.
+    if (nextDeadline === null || nextDeadline === undefined) {
+      // We're out of timer callbacks, so there's no more deadlines and we can now exit.
+      if (timerCallbacks.length === 0) {
+        return;
+      }
+      var nextCallback = timerCallbacks[timerCallbacks.length - 1];
+      nextDeadline = nextCallback.deadline;
+    }
+   
+    // We have a deadline, so check if we've hit it. 
+    var currentTime = new Date();
+    if (currentTime.getTime() < nextDeadline.getTime()) {
+      // We haven't hit the deadline, so just tick the run loop.
+      tickRunLoop(nextDeadline);
+      return;
+    }
+
+    // We hit the deadline, so grab the callback and run it, then tick the run loop.
+    var cb = timerCallbacks.pop();
+    cb.cb();
+    tickRunLoop();
+  }, 1);
+}
+
+setTimeout(function testCallback2() {
+  console.log("running callback");
+  console.log(double(42));
+  console.log(triple(24));
+}, 5000);
+
+tickRunLoop();


### PR DESCRIPTION
This requires serializing a series of references to the component AstRawStrings.
Since they can be variable length, we needed to refactor the return type of the
deserialization functions so they can return both the deserialized value along
with the new offset.