### PR TITLE
Add serialization for Scope VariableMap

### DIFF
--- a/src/ast/scopes.h
+++ b/src/ast/scopes.h
@@ -595,6 +595,8 @@ class V8_EXPORT_PRIVATE Scope : public NON_EXPORTED_BASE(ZoneObject) {
   }
 
  private:
+  friend class BinAstSerializeVisitor;
+  friend class BinAstDeserializer;
   Variable* Declare(Zone* zone, const AstRawString* name, VariableMode mode,
                     VariableKind kind, InitializationFlag initialization_flag,
                     MaybeAssignedFlag maybe_assigned_flag, bool* was_added) {

--- a/src/ast/variables.h
+++ b/src/ast/variables.h
@@ -248,6 +248,8 @@ class Variable final : public ZoneObject {
   using List = base::ThreadedList<Variable>;
 
  private:
+  friend class BinAstSerializeVisitor;
+  friend class BinAstDeserializer;
   Scope* scope_;
   const AstRawString* name_;
 

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -33,13 +33,18 @@ class BinAstDeserializer {
   };
 
   DeserializeResult<uint32_t> DeserializeUint32(ByteArray bytes, int offset);
-  DeserializeResult<int32_t> DeserializeInt32(ByteArray bytes, int offset);
+  DeserializeResult<uint16_t> DeserializeUint16(ByteArray bytes, int offset);
   DeserializeResult<uint8_t> DeserializeUint8(ByteArray bytes, int offset);
+  DeserializeResult<int32_t> DeserializeInt32(ByteArray bytes, int offset);
 
   DeserializeResult<const AstRawString*> DeserializeRawString(ByteArray bytes, int offset);
   DeserializeResult<std::nullptr_t> DeserializeStringTable(ByteArray bytes, int offset);
   DeserializeResult<const AstRawString*> DeserializeRawStringReference(ByteArray bytes, int offset);
   DeserializeResult<AstConsString*> DeserializeConsString(ByteArray bytes, int offset);
+
+  DeserializeResult<Variable*> DeserializeVariable(ByteArray serialized_binast, int offset, Scope* scope);
+  DeserializeResult<std::nullptr_t> DeserializeScopeVariableMap(ByteArray serialized_binast, int offset, Scope* scope);
+  DeserializeResult<DeclarationScope*> DeserializeDeclarationScope(ByteArray serialized_binast, int offset);
 
   DeserializeResult<AstNode*> DeserializeAstNode(ByteArray serialized_ast, int offset);
   DeserializeResult<FunctionLiteral*> DeserializeFunctionLiteral(ByteArray serialized_ast, uint32_t bit_field, int32_t position, int offset);

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -7,6 +7,7 @@
 
 #include "src/parsing/binast-visitor.h"
 #include <mutex>
+#include "src/ast/scopes.h"
 
 namespace v8 {
 namespace internal {
@@ -42,12 +43,16 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
 
  private:
   void SerializeUint32(uint32_t value);
+  void SerializeUint16(uint16_t value);
   void SerializeInt32(int32_t value);
   void SerializeUint8(uint8_t value);
   void SerializeRawString(const AstRawString* s);
   void SerializeConsString(const AstConsString* cons_string);
   void SerializeRawStringReference(const AstRawString* s);
   void SerializeStringTable(const AstConsString* function_name);
+  void SerializeVariable(Variable* variable);
+  void SerializeScopeVariableMap(Scope* scope);
+  void SerializeDeclarationScope(DeclarationScope* scope);
 
   BinAstValueFactory* ast_value_factory_;
   std::unordered_map<const AstRawString*, uint32_t> string_table_indices_;
@@ -66,8 +71,8 @@ inline void BinAstSerializeVisitor::SerializeUint32(uint32_t value) {
   }
 }
 
-inline void BinAstSerializeVisitor::SerializeInt32(int32_t value) {
-  for (size_t i = 0; i < sizeof(uint32_t) / sizeof(uint8_t); ++i) {
+inline void BinAstSerializeVisitor::SerializeUint16(uint16_t value) {
+  for (size_t i = 0; i < sizeof(uint16_t) / sizeof(uint8_t); ++i) {
     size_t shift = sizeof(uint8_t) * 8 * i;
     uint32_t mask = 0xff << shift;
     uint32_t masked_value = value & mask;
@@ -78,8 +83,21 @@ inline void BinAstSerializeVisitor::SerializeInt32(int32_t value) {
   }
 }
 
+
 inline void BinAstSerializeVisitor::SerializeUint8(uint8_t value) {
   byte_data_.push_back(value);
+}
+
+inline void BinAstSerializeVisitor::SerializeInt32(int32_t value) {
+  for (size_t i = 0; i < sizeof(uint32_t) / sizeof(uint8_t); ++i) {
+    size_t shift = sizeof(uint8_t) * 8 * i;
+    uint32_t mask = 0xff << shift;
+    uint32_t masked_value = value & mask;
+    uint32_t final_value = masked_value >> shift;
+    DCHECK(final_value <= 0xff);
+    uint8_t truncated_final_value = final_value;
+    byte_data_.push_back(truncated_final_value);
+  }
 }
 
 void BinAstSerializeVisitor::SerializeRawString(const AstRawString* s) {
@@ -170,11 +188,47 @@ void BinAstSerializeVisitor::SerializeAst(BinAstNode* root) {
   VisitNode(root);
 }
 
+void BinAstSerializeVisitor::SerializeVariable(Variable* variable) {
+  // Variable data:
+  // scope_
+  // name_
+  SerializeRawStringReference(variable->raw_name());
+
+  // local_if_not_shadowed_: TODO(binast): how to reference other local variables like this? index?
+  // next_
+
+  // index_
+  SerializeInt32(variable->index());
+
+  // initializer_position_
+  SerializeInt32(variable->initializer_position());
+
+  // bit_field_
+  SerializeUint16(variable->bit_field_);
+}
+
+void BinAstSerializeVisitor::SerializeScopeVariableMap(Scope* scope) {
+  SerializeUint32(scope->num_var());
+
+  for (VariableMap::Entry* entry = scope->variables_.Start(); entry != nullptr; entry = scope->variables_.Next(entry)) {
+    Variable* variable = reinterpret_cast<Variable*>(entry->value);
+    SerializeVariable(variable);
+  }
+}
+
+void BinAstSerializeVisitor::SerializeDeclarationScope(DeclarationScope* scope) {
+  ScopeType scope_type = scope->scope_type();
+  SerializeUint8(scope_type);
+  SerializeUint8(scope->function_kind());
+  SerializeScopeVariableMap(scope);
+}
+
 void BinAstSerializeVisitor::VisitFunctionLiteral(BinAstFunctionLiteral* function_literal) {
   SerializeUint32(function_literal->bit_field_);
   SerializeInt32(function_literal->position_);
   const AstConsString* name = function_literal->raw_name();
   SerializeConsString(name);
+  SerializeDeclarationScope(function_literal->scope());
 }
 
 void BinAstSerializeVisitor::VisitBlock(BinAstBlock* block) {

--- a/src/parsing/parser.cc
+++ b/src/parsing/parser.cc
@@ -23,6 +23,7 @@
 #include "src/numbers/conversions-inl.h"
 #include "src/objects/scope-info.h"
 #include "src/parsing/parse-info.h"
+#include "src/parsing/binast-deserializer.h"
 #include "src/parsing/rewriter.h"
 #include "src/runtime/runtime.h"
 #include "src/strings/char-predicates-inl.h"
@@ -850,6 +851,28 @@ void Parser::ParseFunction(Isolate* isolate, ParseInfo* info,
   scanner_.Initialize();
 
   FunctionLiteral* result;
+  if (V8_UNLIKELY(shared_info->HasUncompiledDataWithBinAstParseData())) {
+    auto start = std::chrono::high_resolution_clock::now();
+    Handle<BinAstParseData> binast_parse_data = handle(shared_info->uncompiled_data_with_binast_parse_data().binast_parse_data(), isolate);
+    FunctionLiteral* literal;
+    {
+      // We need to setup the parser/initial outer scope before we can start deserialization.
+      Scope* outer = original_scope_;
+      DeclarationScope* outer_function = outer->GetClosureScope();
+      DCHECK(outer);
+      FunctionState function_state(&function_state_, &scope_, outer_function);
+      BlockState block_state(&scope_, outer);
+      BinAstDeserializer deserializer(this);
+      AstNode* ast_node = deserializer.DeserializeAst(binast_parse_data->serialized_ast());
+      literal = ast_node->AsFunctionLiteral();
+      DCHECK(literal != nullptr);
+    }
+    auto elapsed = std::chrono::high_resolution_clock::now() - start;
+    long long microseconds = std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
+    printf("Deserialized function literal in %lld us: %p\n", microseconds, literal);
+    // TODO(binast): Store the literal on the ParseInfo
+  }
+  
   if (V8_UNLIKELY(shared_info->private_name_lookup_skips_outer_class() &&
                   original_scope_->is_class_scope())) {
     // If the function skips the outer class and the outer scope is a class, the

--- a/src/parsing/parsing.cc
+++ b/src/parsing/parsing.cc
@@ -10,7 +10,6 @@
 #include "src/execution/vm-state-inl.h"
 #include "src/handles/maybe-handles.h"
 #include "src/objects/objects-inl.h"
-#include "src/parsing/binast-deserializer.h"
 #include "src/parsing/parse-info.h"
 #include "src/parsing/parser.h"
 #include "src/parsing/rewriter.h"
@@ -88,23 +87,6 @@ bool ParseFunction(ParseInfo* info, Handle<SharedFunctionInfo> shared_info,
 
   // Ok to use Isolate here; this function is only called in the main thread.
   DCHECK(parser.parsing_on_main_thread_);
-
-
-  if (shared_info->HasUncompiledDataWithBinAstParseData()) {
-    // TODO(binast): Actually deserialize the AST, store it on the ParseInfo, and skip normal parsing.
-    auto start = std::chrono::high_resolution_clock::now();
-    Handle<BinAstParseData> binast_parse_data = handle(shared_info->uncompiled_data_with_binast_parse_data().binast_parse_data(), isolate);
-    // TODO(binast): Probably hide all this stuff inside the parsing module
-    BinAstDeserializer deserializer(&parser);
-    AstNode* ast_node = deserializer.DeserializeAst(binast_parse_data->serialized_ast());
-    DCHECK(ast_node->node_type() == AstNode::NodeType::kFunctionLiteral);
-    FunctionLiteral* literal = ast_node->AsFunctionLiteral();
-    DCHECK(literal != nullptr);
-    auto elapsed = std::chrono::high_resolution_clock::now() - start;
-    long long microseconds = std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
-    printf("Deserialized function literal in %lld us: %p\n", microseconds, literal);
-    // TODO(binast): Store the literal on the ParseInfo
-  }
 
   parser.ParseFunction(isolate, info, shared_info);
   MaybeReportErrorsAndStatistics(info, script, isolate, &parser, mode);


### PR DESCRIPTION
This is where all Scope objects store the variables that are declared within
their represented scopes. This is a small portion of serialization of Scopes
(and DeclarationScopes in particular).