### PR TITLE
Add support for proper deserialization of Scope locals_

### DIFF
--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -42,7 +42,8 @@ class BinAstDeserializer {
   DeserializeResult<const AstRawString*> DeserializeRawStringReference(ByteArray bytes, int offset);
   DeserializeResult<AstConsString*> DeserializeConsString(ByteArray bytes, int offset);
 
-  DeserializeResult<Variable*> DeserializeVariable(ByteArray serialized_binast, int offset, Scope* scope);
+  DeserializeResult<Variable*> DeserializeLocalVariable(ByteArray serialized_binast, int offset, Scope* scope);
+  DeserializeResult<Variable*> DeserializeNonLocalVariable(ByteArray serialized_binast, int offset, Scope* scope);
   DeserializeResult<std::nullptr_t> DeserializeScopeVariableMap(ByteArray serialized_binast, int offset, Scope* scope);
   DeserializeResult<DeclarationScope*> DeserializeDeclarationScope(ByteArray serialized_binast, int offset);
 

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -152,9 +152,10 @@ void BinAstSerializeVisitor::SerializeStringTable(const AstConsString* function_
   // TODO(binast): Do we need to?
   if (function_name != nullptr) {
     for (const AstRawString* s : function_name->ToRawStrings()) {
-      DCHECK(s != nullptr);
-      (void)s;
-      num_entries += 1;
+      void* key = const_cast<AstRawString*>(s);
+      if (ast_value_factory_->string_table_.Lookup(key, s->Hash()) == nullptr) {
+        num_entries += 1;
+      }
     }
   }
   SerializeUint32(num_entries);
@@ -168,9 +169,12 @@ void BinAstSerializeVisitor::SerializeStringTable(const AstConsString* function_
 
   if (function_name != nullptr) {
     for (const AstRawString* s : function_name->ToRawStrings()) {
-      SerializeRawString(s);
-      string_table_indices_.insert({s, current_index});
-      current_index += 1;
+      void* key = const_cast<AstRawString*>(s);
+      if (ast_value_factory_->string_table_.Lookup(key, s->Hash()) == nullptr) {
+        SerializeRawString(s);
+        string_table_indices_.insert({s, current_index});
+        current_index += 1;
+      }
     }
   }
 
@@ -182,38 +186,57 @@ void BinAstSerializeVisitor::SerializeAst(BinAstNode* root) {
   static std::mutex global_lock;
   std::lock_guard<std::mutex> lock(global_lock);
 
+  auto start = std::chrono::high_resolution_clock::now();
   BinAstFunctionLiteral* literal = root->AsFunctionLiteral();
   DCHECK(literal != nullptr);
   SerializeStringTable(literal->raw_name());
   VisitNode(root);
+
+  auto elapsed = std::chrono::high_resolution_clock::now() - start;
+  long long microseconds = std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
+  printf("Serialized function: '");
+  for (const AstRawString* s : literal->raw_name()->ToRawStrings()) {
+    printf("%.*s", s->byte_length(), s->raw_data());
+  }
+  printf("' in %lld us\n", microseconds);
 }
 
 void BinAstSerializeVisitor::SerializeVariable(Variable* variable) {
-  // Variable data:
-  // scope_
-  // name_
   SerializeRawStringReference(variable->raw_name());
 
   // local_if_not_shadowed_: TODO(binast): how to reference other local variables like this? index?
-  // next_
 
-  // index_
   SerializeInt32(variable->index());
-
-  // initializer_position_
   SerializeInt32(variable->initializer_position());
-
-  // bit_field_
   SerializeUint16(variable->bit_field_);
 }
 
 void BinAstSerializeVisitor::SerializeScopeVariableMap(Scope* scope) {
-  SerializeUint32(scope->num_var());
+  // Serialize locals first.
+  std::unordered_set<const AstRawString*> locals;
+  for (Variable* variable : scope->locals_) {
+    locals.insert(variable->raw_name());
+  }
 
-  for (VariableMap::Entry* entry = scope->variables_.Start(); entry != nullptr; entry = scope->variables_.Next(entry)) {
-    Variable* variable = reinterpret_cast<Variable*>(entry->value);
+  DCHECK(locals.size() < UINT32_MAX);
+  uint32_t total_local_vars = static_cast<uint32_t>(locals.size());
+  SerializeUint32(total_local_vars);
+  for (Variable* variable : scope->locals_) {
     SerializeVariable(variable);
   }
+
+  // Now serialize any remaining variables we missed
+  uint32_t total_nonlocal_vars = scope->num_var() - total_local_vars;
+  uint32_t serialized_nonlocal_vars = 0;
+  SerializeUint32(total_nonlocal_vars);
+  for (VariableMap::Entry* entry = scope->variables_.Start(); entry != nullptr; entry = scope->variables_.Next(entry)) {
+    Variable* variable = reinterpret_cast<Variable*>(entry->value);
+    if (locals.count(variable->raw_name()) == 0) {
+      SerializeVariable(variable);
+      serialized_nonlocal_vars += 1;
+    }
+  }
+  DCHECK(total_nonlocal_vars == serialized_nonlocal_vars);
 }
 
 void BinAstSerializeVisitor::SerializeDeclarationScope(DeclarationScope* scope) {

--- a/src/parsing/parser.cc
+++ b/src/parsing/parser.cc
@@ -869,7 +869,13 @@ void Parser::ParseFunction(Isolate* isolate, ParseInfo* info,
     }
     auto elapsed = std::chrono::high_resolution_clock::now() - start;
     long long microseconds = std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
-    printf("Deserialized function literal in %lld us: %p\n", microseconds, literal);
+    printf("Deserialized function literal for '");
+    if (literal->has_shared_name()) {
+      for (const AstRawString* s : literal->raw_name()->ToRawStrings()) {
+        printf("%.*s", s->byte_length(), s->raw_data());
+      }
+    }
+    printf("' in %lld us: %p\n", microseconds, literal);
     // TODO(binast): Store the literal on the ParseInfo
   }
   

--- a/test/binast/test.js
+++ b/test/binast/test.js
@@ -20,7 +20,7 @@ function newSetTimeout(func, delayMs) {
 setTimeout = newSetTimeout;
 
 function tickRunLoop(nextDeadline) {
-  oldSetTimeout(function() {
+  oldSetTimeout(function timeoutCallback() {
     // We don't currently have a deadline, so look for the next timer callback to find a new deadline.
     if (nextDeadline === null || nextDeadline === undefined) {
       // We're out of timer callbacks, so there's no more deadlines and we can now exit.
@@ -30,6 +30,7 @@ function tickRunLoop(nextDeadline) {
       var nextCallback = timerCallbacks[timerCallbacks.length - 1];
       nextDeadline = nextCallback.deadline;
     }
+
    
     // We have a deadline, so check if we've hit it. 
     var currentTime = new Date();


### PR DESCRIPTION
Previously we weren't using the correct Declare method to add to the locals_
variable and we were serializing in the order of the VariableMap instead of
in the order of locals_. We were also doing some stuff incorrectly that was
triggering an assert when serializing AstRawStrings for named functions.
This diff fixes those issues and modifies the test file to trigger it in the future.