### PR TITLE
Add support for serializing Scope Declarations

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -387,6 +387,7 @@ class Declaration : public ZoneObject {
   int position() const { return start_pos_; }
 
  protected:
+  friend class BinAstDeserializer;
   Declaration(int pos, DeclType type) : start_pos_(pos), type_(type), var_(nullptr), next_(nullptr) {}
 
  private:

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -6,6 +6,7 @@
 #define V8_PARSING_BINAST_DESERIALIZER_H_
 
 #include <unordered_map>
+#include "src/parsing/parser.h"
 #include "src/handles/handles.h"
 
 namespace v8 {
@@ -13,9 +14,9 @@ namespace internal {
 
 class AstNode;
 class ByteArray;
+class Declaration;
 class FunctionLiteral;
 class ParseInfo;
-class Parser;
 class AstConsString;
 class AstRawString;
 
@@ -32,6 +33,8 @@ class BinAstDeserializer {
     int new_offset;
   };
 
+  Zone* zone() { return parser_->zone(); }
+
   DeserializeResult<uint32_t> DeserializeUint32(ByteArray bytes, int offset);
   DeserializeResult<uint16_t> DeserializeUint16(ByteArray bytes, int offset);
   DeserializeResult<uint8_t> DeserializeUint8(ByteArray bytes, int offset);
@@ -44,7 +47,10 @@ class BinAstDeserializer {
 
   DeserializeResult<Variable*> DeserializeLocalVariable(ByteArray serialized_binast, int offset, Scope* scope);
   DeserializeResult<Variable*> DeserializeNonLocalVariable(ByteArray serialized_binast, int offset, Scope* scope);
+  DeserializeResult<Variable*> DeserializeScopeVariableReference(ByteArray serialized_binast, int offset, Scope* scope);
   DeserializeResult<std::nullptr_t> DeserializeScopeVariableMap(ByteArray serialized_binast, int offset, Scope* scope);
+  DeserializeResult<Declaration*> DeserializeDeclaration(ByteArray serialized_binast, int offset, Scope* scope);
+  DeserializeResult<std::nullptr_t> DeserializeScopeDeclarations(ByteArray serialized_binast, int offset, Scope* scope);
   DeserializeResult<DeclarationScope*> DeserializeDeclarationScope(ByteArray serialized_binast, int offset);
 
   DeserializeResult<AstNode*> DeserializeAstNode(ByteArray serialized_ast, int offset);
@@ -52,6 +58,7 @@ class BinAstDeserializer {
 
   Parser* parser_;
   std::unordered_map<uint32_t, const AstRawString*> string_table_;
+  std::unordered_map<Scope*, std::unordered_map<uint32_t, Variable*>> variables_by_scope_;
 };
 
 }  // namespace internal

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -51,12 +51,17 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   void SerializeRawStringReference(const AstRawString* s);
   void SerializeStringTable(const AstConsString* function_name);
   void SerializeVariable(Variable* variable);
+  void SerializeScopeVariableReference(Scope* scope, Variable* variable);
   void SerializeScopeVariableMap(Scope* scope);
+  void SerializeDeclaration(Scope* scope, Declaration* decl);
+  void SerializeScopeDeclarations(Scope* scope);
   void SerializeDeclarationScope(DeclarationScope* scope);
+
 
   AstValueFactory* ast_value_factory_;
   std::unordered_map<const AstRawString*, uint32_t> string_table_indices_;
   std::vector<uint8_t> byte_data_;
+  std::unordered_map<Scope*, std::unordered_map<Variable*, uint32_t>> vars_by_scope_;
 };
 
 inline void BinAstSerializeVisitor::SerializeUint32(uint32_t value) {
@@ -207,6 +212,17 @@ void BinAstSerializeVisitor::SerializeVariable(Variable* variable) {
   SerializeUint16(variable->bit_field_);
 }
 
+void BinAstSerializeVisitor::SerializeScopeVariableReference(Scope* scope, Variable* variable) {
+  auto scope_var_ids_result = vars_by_scope_.find(scope);
+  DCHECK(scope_var_ids_result != vars_by_scope_.end());
+  std::unordered_map<Variable*, uint32_t>& scope_var_ids = scope_var_ids_result->second;
+
+  auto var_id_result = scope_var_ids.find(variable);
+  DCHECK(var_id_result != scope_var_ids.end());
+  uint32_t var_id = var_id_result->second;
+  SerializeUint32(var_id);
+}
+
 void BinAstSerializeVisitor::SerializeScopeVariableMap(Scope* scope) {
   // Serialize locals first.
   std::unordered_set<const AstRawString*> locals;
@@ -214,11 +230,16 @@ void BinAstSerializeVisitor::SerializeScopeVariableMap(Scope* scope) {
     locals.insert(variable->raw_name());
   }
 
+  DCHECK(vars_by_scope_.count(scope) == 0);
+  vars_by_scope_.insert({scope, std::unordered_map<Variable*, uint32_t>()});
+  std::unordered_map<Variable*, uint32_t>& var_ids = vars_by_scope_[scope];
+
   DCHECK(locals.size() < UINT32_MAX);
   uint32_t total_local_vars = static_cast<uint32_t>(locals.size());
   SerializeUint32(total_local_vars);
   for (Variable* variable : scope->locals_) {
     SerializeVariable(variable);
+    var_ids.insert({variable, var_ids.size()});
   }
 
   // Now serialize any remaining variables we missed
@@ -229,10 +250,31 @@ void BinAstSerializeVisitor::SerializeScopeVariableMap(Scope* scope) {
     Variable* variable = reinterpret_cast<Variable*>(entry->value);
     if (locals.count(variable->raw_name()) == 0) {
       SerializeVariable(variable);
+      var_ids.insert({variable, var_ids.size()});
       serialized_nonlocal_vars += 1;
     }
   }
   DCHECK(total_nonlocal_vars == serialized_nonlocal_vars);
+}
+
+void BinAstSerializeVisitor::SerializeDeclaration(Scope* scope, Declaration* decl) {
+  SerializeInt32(decl->position());
+  SerializeUint8(decl->type());
+  SerializeScopeVariableReference(scope, decl->var());
+}
+
+void BinAstSerializeVisitor::SerializeScopeDeclarations(Scope* scope) {
+  uint32_t num_decls = 0;
+  for (Declaration* decl : *scope->declarations()) {
+    (void)decl;
+    num_decls += 1;
+  }
+
+  SerializeUint32(num_decls);
+
+  for (Declaration* decl : *scope->declarations()) {
+    SerializeDeclaration(scope, decl);
+  }
 }
 
 void BinAstSerializeVisitor::SerializeDeclarationScope(DeclarationScope* scope) {
@@ -240,6 +282,7 @@ void BinAstSerializeVisitor::SerializeDeclarationScope(DeclarationScope* scope) 
   SerializeUint8(scope_type);
   SerializeUint8(scope->function_kind());
   SerializeScopeVariableMap(scope);
+  SerializeScopeDeclarations(scope);
 }
 
 void BinAstSerializeVisitor::VisitFunctionLiteral(FunctionLiteral* function_literal) {


### PR DESCRIPTION
The binAST serializer now supports serializing and deserializing the decls_
field in Scope. This required adding an additional map to keep track of
which Scopes contain references to which variables.