### PR TITLE
Finish de/serialization support for FunctionLiteral

### DIFF
--- a/src/ast/ast.cc
+++ b/src/ast/ast.cc
@@ -82,6 +82,14 @@ MaterializedLiteral* AstNode::AsMaterializedLiteral() {
   }
 }
 
+Statement* AstNode::AsStatement() {
+  switch (node_type()) {
+    STATEMENT_NODE_LIST(RETURN_NODE);
+    default:
+      return nullptr;
+  }
+}
+
 #undef RETURN_NODE
 
 bool Expression::IsSmiLiteral() const {

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -171,6 +171,7 @@ class AstNode: public ZoneObject {
   FAILURE_NODE_LIST(DECLARE_NODE_FUNCTIONS)
 #undef DECLARE_NODE_FUNCTIONS
 
+  Statement* AsStatement();
   IterationStatement* AsIterationStatement();
   MaterializedLiteral* AsMaterializedLiteral();
 
@@ -2463,6 +2464,7 @@ class FunctionLiteral final : public Expression {
  private:
   friend class AstNodeFactory;
   friend class BinAstSerializeVisitor;
+  friend class BinAstDeserializer;
 
   FunctionLiteral(Zone* zone, const AstConsString* name,
                   AstValueFactory* ast_value_factory, DeclarationScope* scope,

--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -144,6 +144,8 @@ AstNode* BinAstDeserializer::DeserializeAst(ByteArray serialized_ast) {
   auto string_table_result = DeserializeStringTable(serialized_ast, offset);
   offset = string_table_result.new_offset;
   auto result = DeserializeAstNode(serialized_ast, offset);
+  // Check that we consumed all the bytes that were serialized.
+  DCHECK(result.new_offset == serialized_ast.length());
   return result.value;
 }
 
@@ -158,6 +160,25 @@ BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::DeserializeA
   switch (nodeType) {
   case AstNode::kFunctionLiteral: {
     auto result = DeserializeFunctionLiteral(serialized_binast, bit_field.value, position.value, offset);
+    return {result.value, result.new_offset};
+  }
+  case AstNode::kBlock:
+  case AstNode::kIfStatement:
+  case AstNode::kExpressionStatement:
+  case AstNode::kLiteral:
+  case AstNode::kEmptyStatement:
+  case AstNode::kAssignment:
+  case AstNode::kVariableProxyExpression:
+  case AstNode::kForStatement:
+  case AstNode::kCompareOperation:
+  case AstNode::kCountOperation:
+  case AstNode::kCall:
+  case AstNode::kProperty:
+  case AstNode::kReturnStatement:
+  case AstNode::kBinaryOperation:
+  case AstNode::kObjectLiteral:
+  case AstNode::kArrayLiteral: {
+    auto result = DeserializeNodeStub(serialized_binast, bit_field.value, position.value, offset);
     return {result.value, result.new_offset};
   }
   default: {
@@ -485,7 +506,6 @@ BinAstDeserializer::DeserializeResult<DeclarationScope*> BinAstDeserializer::Des
 }
 
 BinAstDeserializer::DeserializeResult<FunctionLiteral*> BinAstDeserializer::DeserializeFunctionLiteral(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  std::vector<void*> pointer_buffer;
   // TODO(binast): Kind of silly that we serialize a cons string only to deserialized into a raw string
   auto name = DeserializeConsString(serialized_binast, offset);
   offset = name.new_offset;
@@ -505,22 +525,56 @@ BinAstDeserializer::DeserializeResult<FunctionLiteral*> BinAstDeserializer::Dese
   auto scope = DeserializeDeclarationScope(serialized_binast, offset);
   offset = scope.new_offset;
   
-  /* TODO */const ScopedPtrList<Statement> body(&pointer_buffer);
-  /* TODO */int expected_property_count = 0;
-  /* TODO */int parameter_count = 0;
-  /* TODO */int function_length = 0;
-  /* TODO */FunctionLiteral::ParameterFlag has_duplicate_parameters = FunctionLiteral::ParameterFlag::kNoDuplicateParameters;
-  /* TODO */FunctionSyntaxKind function_syntax_kind = FunctionSyntaxKind::kDeclaration;
-  /* TODO */FunctionLiteral::EagerCompileHint eager_compile_hint = FunctionLiteral::EagerCompileHint::kShouldLazyCompile;
-  /* TODO */bool has_braces = false;
-  /* TODO */int function_literal_id = 0;
+  auto expected_property_count = DeserializeInt32(serialized_binast, offset);
+  offset = expected_property_count.new_offset;
+
+  auto parameter_count = DeserializeInt32(serialized_binast, offset);
+  offset = parameter_count.new_offset;
+
+  auto function_length = DeserializeInt32(serialized_binast, offset);
+  offset = function_length.new_offset;
+
+  auto function_token_position = DeserializeInt32(serialized_binast, offset);
+  offset = function_token_position.new_offset;
+
+  auto suspend_count = DeserializeInt32(serialized_binast, offset);
+  offset = suspend_count.new_offset;
+
+  auto function_literal_id = DeserializeInt32(serialized_binast, offset);
+  offset = function_literal_id.new_offset;
+
+  FunctionLiteral::ParameterFlag has_duplicate_parameters = FunctionLiteral::HasDuplicateParameters::decode(bit_field) ? FunctionLiteral::ParameterFlag::kHasDuplicateParameters : FunctionLiteral::ParameterFlag::kNoDuplicateParameters;
+  FunctionSyntaxKind function_syntax_kind = FunctionLiteral::FunctionSyntaxKindBits::decode(bit_field);
+  FunctionLiteral::EagerCompileHint eager_compile_hint = scope.value->ShouldEagerCompile() ? FunctionLiteral::kShouldEagerCompile : FunctionLiteral::kShouldLazyCompile;
+  bool has_braces = FunctionLiteral::HasBracesField::decode(bit_field);
+
+  std::vector<void*> pointer_buffer;
+  ScopedPtrList<Statement> body(&pointer_buffer);
+  auto num_statements = DeserializeInt32(serialized_binast, offset);
+  offset = num_statements.new_offset;
+
+  for (int i = 0; i < num_statements.value; ++i) {
+    auto statement = DeserializeAstNode(serialized_binast, offset);
+    offset = statement.new_offset;
+    DCHECK(statement.value == nullptr || statement.value->AsStatement() != nullptr);
+    body.Add(static_cast<Statement*>(statement.value));
+  }
+
   FunctionLiteral* result = parser_->factory()->NewFunctionLiteral(
-    raw_name, scope.value, body, expected_property_count, parameter_count, 
-    function_length, has_duplicate_parameters, function_syntax_kind,
-    eager_compile_hint, position, has_braces, function_literal_id);
+    raw_name, scope.value, body, expected_property_count.value, parameter_count.value,
+    function_length.value, has_duplicate_parameters, function_syntax_kind,
+    eager_compile_hint, position, has_braces, function_literal_id.value);
+
+  result->function_token_position_ = function_token_position.value;
+  result->suspend_count_ = suspend_count.value;
+
   return {result, offset};
 }
 
+// This is just a placeholder while we implement the various nodes that we'll support.
+BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::DeserializeNodeStub(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset) {
+  return {nullptr, offset};
+}
 
 }  // namespace internal
 }  // namespace v8

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -59,6 +59,7 @@ class BinAstDeserializer {
 
   DeserializeResult<AstNode*> DeserializeAstNode(ByteArray serialized_ast, int offset);
   DeserializeResult<FunctionLiteral*> DeserializeFunctionLiteral(ByteArray serialized_ast, uint32_t bit_field, int32_t position, int offset);
+  DeserializeResult<std::nullptr_t> DeserializeNodeStub(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset);
 
   Parser* parser_;
   std::unordered_map<uint32_t, const AstRawString*> string_table_;

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -66,6 +66,7 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   void SerializeScopeDeclarations(Scope* scope);
   void SerializeScopeParameters(DeclarationScope* scope);
   void SerializeDeclarationScope(DeclarationScope* scope);
+  void SerializeAstNodeHeader(AstNode* node);
 
 
   AstValueFactory* ast_value_factory_;
@@ -401,76 +402,108 @@ inline void BinAstSerializeVisitor::SerializeDeclarationScope(DeclarationScope* 
   DCHECK(scope->rare_data_ == nullptr);
 }
 
+inline void BinAstSerializeVisitor::SerializeAstNodeHeader(AstNode* node) {
+  SerializeUint32(node->bit_field_);
+  SerializeInt32(node->position_);
+}
+
 inline void BinAstSerializeVisitor::VisitFunctionLiteral(FunctionLiteral* function_literal) {
-  SerializeUint32(function_literal->bit_field_);
-  SerializeInt32(function_literal->position_);
+  SerializeAstNodeHeader(function_literal);
   const AstConsString* name = function_literal->raw_name();
   SerializeConsString(name);
   SerializeDeclarationScope(function_literal->scope());
+
+  SerializeInt32(function_literal->expected_property_count());
+  SerializeInt32(function_literal->parameter_count());
+  SerializeInt32(function_literal->function_length());
+  SerializeInt32(function_literal->function_token_position());
+  SerializeInt32(function_literal->suspend_count());
+  SerializeInt32(function_literal->function_literal_id());
+
+  SerializeInt32(function_literal->body()->length());
+  for (Statement* statement : *function_literal->body()) {
+    VisitNode(statement);
+  }
 }
 
 inline void BinAstSerializeVisitor::VisitBlock(Block* block) {
-
+  SerializeAstNodeHeader(block);
+  // TODO(binast)
 }
 
 inline void BinAstSerializeVisitor::VisitIfStatement(IfStatement* if_statement) {
-
+  SerializeAstNodeHeader(if_statement);
+  // TODO(binast)
 }
 
 inline void BinAstSerializeVisitor::VisitExpressionStatement(ExpressionStatement* statement) {
-
+  SerializeAstNodeHeader(statement);
+  // TODO(binast)
 }
 
 inline void BinAstSerializeVisitor::VisitLiteral(Literal* literal) {
-
+  SerializeAstNodeHeader(literal);
+  // TODO(binast)
 }
 
 inline void BinAstSerializeVisitor::VisitEmptyStatement(EmptyStatement* empty_statement) {
-
+  SerializeAstNodeHeader(empty_statement);
+  // TODO(binast)
 }
 
 inline void BinAstSerializeVisitor::VisitAssignment(Assignment* assignment) {
-
+  SerializeAstNodeHeader(assignment);
+  // TODO(binast)
 }
 
 inline void BinAstSerializeVisitor::VisitVariableProxyExpression(VariableProxyExpression* var_proxy) {
-
+  SerializeAstNodeHeader(var_proxy);
+  // TODO(binast)
 }
 
 inline void BinAstSerializeVisitor::VisitForStatement(ForStatement* for_statement) {
-
+  SerializeAstNodeHeader(for_statement);
+  // TODO(binast)
 }
 
 inline void BinAstSerializeVisitor::VisitCompareOperation(CompareOperation* compare) {
-
+  SerializeAstNodeHeader(compare);
+  // TODO(binast)
 }
 
 inline void BinAstSerializeVisitor::VisitCountOperation(CountOperation* operation) {
-
+  SerializeAstNodeHeader(operation);
+  // TODO(binast)
 }
 
 inline void BinAstSerializeVisitor::VisitCall(Call* call) {
-
+  SerializeAstNodeHeader(call);
+  // TODO(binast)
 }
 
 inline void BinAstSerializeVisitor::VisitProperty(Property* property) {
-
+  SerializeAstNodeHeader(property);
+  // TODO(binast)
 }
 
 inline void BinAstSerializeVisitor::VisitReturnStatement(ReturnStatement* return_statement) {
-
+  SerializeAstNodeHeader(return_statement);
+  // TODO(binast)
 }
 
 inline void BinAstSerializeVisitor::VisitBinaryOperation(BinaryOperation* binary_op) {
-
+  SerializeAstNodeHeader(binary_op);
+  // TODO(binast)
 }
 
 inline void BinAstSerializeVisitor::VisitObjectLiteral(ObjectLiteral* object_literal) {
-  
+  SerializeAstNodeHeader(object_literal);
+  // TODO(binast)
 }
 
 inline void BinAstSerializeVisitor::VisitArrayLiteral(ArrayLiteral* array_literal) {
-  
+  SerializeAstNodeHeader(array_literal);
+  // TODO(binast)
 }
 
 }  // namespace internal


### PR DESCRIPTION
This adds the remaining fields for FunctionLiteral as well as a stubbed out
version of the de/serialization logic for the rest of the nodes we currently
support in the visitor.