### PR TITLE
Add de/serialization support for ExpressionStatement and VariableProx…

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1640,6 +1640,8 @@ class VariableProxy final : public ZoneObject {
  private:
   friend class AstNodeFactory;
   friend class BinAstNodeFactory;
+  friend class BinAstSerializeVisitor;
+  friend class BinAstDeserializer;
 
   VariableProxy(Variable* var, int start_position);
 
@@ -1729,6 +1731,7 @@ class VariableProxyExpression final : public Expression {
 
  private:
   friend class AstNodeFactory;
+  friend class BinAstSerializeVisitor;
 
   VariableProxyExpression(VariableProxy* proxy)
       : Expression(proxy->position(), kVariableProxyExpression),

--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -139,6 +139,20 @@ BinAstDeserializer::DeserializeResult<AstConsString*> BinAstDeserializer::Deseri
   return {cons_string, offset};
 }
 
+void BinAstDeserializer::LinkUnresolvedVariableProxies() {
+  for (auto it = variable_proxies_by_position_.begin(); it != variable_proxies_by_position_.end(); ++it) {
+    VariableProxy* var_proxy = it->second;
+    if (var_proxy->next_unresolved_ == nullptr) {
+      continue;
+    }
+
+    int next_unresolved_position = (int)(std::intptr_t)var_proxy->next_unresolved_;
+    auto lookup_result = variable_proxies_by_position_.find(next_unresolved_position);
+    DCHECK(lookup_result != variable_proxies_by_position_.end());
+    var_proxy->next_unresolved_ = lookup_result->second;
+  }
+}
+
 AstNode* BinAstDeserializer::DeserializeAst(ByteArray serialized_ast) {
   int offset = 0;
   auto string_table_result = DeserializeStringTable(serialized_ast, offset);
@@ -146,6 +160,7 @@ AstNode* BinAstDeserializer::DeserializeAst(ByteArray serialized_ast) {
   auto result = DeserializeAstNode(serialized_ast, offset);
   // Check that we consumed all the bytes that were serialized.
   DCHECK(result.new_offset == serialized_ast.length());
+  LinkUnresolvedVariableProxies();
   return result.value;
 }
 
@@ -174,13 +189,19 @@ BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::DeserializeA
     auto result = DeserializeProperty(serialized_binast, bit_field.value, position.value, offset);
     return {result.value, result.new_offset};
   }
+  case AstNode::kExpressionStatement: {
+    auto result = DeserializeExpressionStatement(serialized_binast, bit_field.value, position.value, offset);
+    return {result.value, result.new_offset};
+  }
+  case AstNode::kVariableProxyExpression: {
+    auto result = DeserializeVariableProxyExpression(serialized_binast, bit_field.value, position.value, offset);
+    return {result.value, result.new_offset};
+  }
   case AstNode::kBlock:
   case AstNode::kIfStatement:
-  case AstNode::kExpressionStatement:
   case AstNode::kLiteral:
   case AstNode::kEmptyStatement:
   case AstNode::kAssignment:
-  case AstNode::kVariableProxyExpression:
   case AstNode::kForStatement:
   case AstNode::kCompareOperation:
   case AstNode::kCountOperation:
@@ -252,7 +273,7 @@ BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::Deserialize
   return {variable, offset};
 }
 
-BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::DeserializeScopeVariableReference(ByteArray serialized_binast, int offset, Scope* scope) {
+BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::DeserializeVariableReference(ByteArray serialized_binast, int offset) {
   auto variable_reference = DeserializeUint32(serialized_binast, offset);
   offset = variable_reference.new_offset;
 
@@ -260,12 +281,8 @@ BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::Deserialize
     return {nullptr, offset};
   }
 
-  auto scope_vars_by_id_result = variables_by_scope_.find(scope);
-  DCHECK(scope_vars_by_id_result != variables_by_scope_.end());
-  std::unordered_map<uint32_t, Variable*>& scope_vars_by_id = scope_vars_by_id_result->second;
-
-  auto variable_result = scope_vars_by_id.find(variable_reference.value);
-  DCHECK(variable_result != scope_vars_by_id.end());
+  auto variable_result = variables_by_id_.find(variable_reference.value);
+  DCHECK(variable_result != variables_by_id_.end());
   Variable* variable = variable_result->second;
 
   return {variable, offset};
@@ -279,8 +296,36 @@ BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::Deserialize
   if (variable == nullptr) {
     return {nullptr, offset};
   }
-  auto& vars_in_scope = variables_by_scope_[scope];
-  vars_in_scope.insert({vars_in_scope.size() + 1, variable});
+  variables_by_id_.insert({variables_by_id_.size() + 1, variable});
+  return {variable, offset};
+}
+
+// This is for Variables that didn't belong to any particular Scope, i.e. their scope_ field was null.
+BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::DeserializeNonScopeVariable(ByteArray serialized_binast, int offset) {
+  auto name = DeserializeRawStringReference(serialized_binast, offset);
+  offset = name.new_offset;
+
+  if (name.value == nullptr) {
+    return {nullptr, offset};
+  }
+
+  // local_if_not_shadowed_: TODO(binast): how to reference other local variables like this? index?
+  // next_
+
+  auto index = DeserializeInt32(serialized_binast, offset);
+  offset = index.new_offset;
+
+  auto initializer_position = DeserializeInt32(serialized_binast, offset);
+  offset = initializer_position.new_offset;
+
+  auto bit_field = DeserializeUint16(serialized_binast, offset);
+  offset = bit_field.new_offset;
+
+  // We just use bogus values for mode, etc. since they're already encoded in the bit field
+  Variable* variable = new (zone()) Variable(nullptr, name.value, VariableMode::kVar, NORMAL_VARIABLE, kCreatedInitialized, kMaybeAssigned, IsStaticFlag::kNotStatic);
+  variable->index_ = index.value;
+  variable->initializer_position_ = initializer_position.value;
+  variable->bit_field_ = bit_field.value;
   return {variable, offset};
 }
 
@@ -299,7 +344,7 @@ BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::Deserialize
       return {scope_result.value, offset};
     }
     case ScopeVariableKind::Reference: {
-      auto scope_result = DeserializeScopeVariableReference(serialized_binast, offset, scope);
+      auto scope_result = DeserializeVariableReference(serialized_binast, offset);
       offset = scope_result.new_offset;
       return {scope_result.value, offset};
     }
@@ -309,18 +354,37 @@ BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::Deserialize
   }
 }
 
+BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::DeserializeNonScopeVariableOrReference(ByteArray serialized_binast, int offset) {
+  auto marker_result = DeserializeUint8(serialized_binast, offset);
+  offset = marker_result.new_offset;
+
+  switch (marker_result.value) {
+    case ScopeVariableKind::Null: {
+      return {nullptr, offset};
+    }
+    case ScopeVariableKind::Definition: {
+      auto scope_result = DeserializeNonScopeVariable(serialized_binast, offset);
+      offset = scope_result.new_offset;
+      return {scope_result.value, offset};
+    }
+    case ScopeVariableKind::Reference: {
+      auto scope_result = DeserializeVariableReference(serialized_binast, offset);
+      offset = scope_result.new_offset;
+      return {scope_result.value, offset};
+    }
+    default: {
+      UNREACHABLE();
+    }
+  }
+}
 
 BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::DeserializeScopeVariableMap(ByteArray serialized_binast, int offset, Scope* scope) {
   auto total_local_variables = DeserializeUint32(serialized_binast, offset);
   offset = total_local_variables.new_offset;
 
-  DCHECK(variables_by_scope_.count(scope) == 0);
-  variables_by_scope_.insert({scope, std::unordered_map<uint32_t, Variable*>()});
-  std::unordered_map<uint32_t, Variable*>& scope_vars_by_id = variables_by_scope_[scope];
-
   for (uint32_t i = 0; i < total_local_variables.value; ++i) {
     auto new_variable = DeserializeLocalVariable(serialized_binast, offset, scope);
-    scope_vars_by_id.insert({scope_vars_by_id.size() + 1, new_variable.value});
+    variables_by_id_.insert({variables_by_id_.size() + 1, new_variable.value});
     offset = new_variable.new_offset;
   }
 
@@ -329,7 +393,7 @@ BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::Deseri
 
   for (uint32_t i = 0; i < total_nonlocal_variables.value; ++i) {
     auto new_variable = DeserializeNonLocalVariable(serialized_binast, offset, scope);
-    scope_vars_by_id.insert({scope_vars_by_id.size() + 1, new_variable.value});
+    variables_by_id_.insert({variables_by_id_.size() + 1, new_variable.value});
     offset = new_variable.new_offset;
   }
 
@@ -343,7 +407,7 @@ BinAstDeserializer::DeserializeResult<Declaration*> BinAstDeserializer::Deserial
   auto decl_type = DeserializeUint8(serialized_binast, offset);
   offset = decl_type.new_offset;
 
-  auto variable = DeserializeScopeVariableReference(serialized_binast, offset, scope);
+  auto variable = DeserializeVariableReference(serialized_binast, offset);
   offset = variable.new_offset;
 
   Declaration* decl = new (zone()) Declaration(start_pos.value, static_cast<Declaration::DeclType>(decl_type.value));
@@ -370,7 +434,7 @@ BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::Deseri
   scope->num_parameters_ = num_parameters_result.value;
 
   for (int i = 0; i < num_parameters_result.value; ++i) {
-    auto param_result = DeserializeScopeVariableReference(serialized_binast, offset, scope);
+    auto param_result = DeserializeVariableReference(serialized_binast, offset);
     offset = param_result.new_offset;
     scope->params_.Add(param_result.value, zone());
   }
@@ -614,6 +678,66 @@ BinAstDeserializer::DeserializeResult<Property*> BinAstDeserializer::Deserialize
   offset = key.new_offset;
 
   Property* result = parser_->factory()->NewProperty(static_cast<Expression*>(obj.value), static_cast<Expression*>(key.value), position);
+  result->bit_field_ = bit_field;
+  return {result, offset};
+}
+
+BinAstDeserializer::DeserializeResult<ExpressionStatement*> BinAstDeserializer::DeserializeExpressionStatement(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset) {
+  auto expression = DeserializeAstNode(serialized_binast, offset);
+  offset = expression.new_offset;
+
+  ExpressionStatement* result = parser_->factory()->NewExpressionStatement(static_cast<Expression*>(expression.value), offset);
+  result->bit_field_ = bit_field;
+  return {result, offset};
+}
+
+BinAstDeserializer::DeserializeResult<VariableProxy*> BinAstDeserializer::DeserializeVariableProxy(ByteArray serialized_binast, int offset) {
+  auto position = DeserializeInt32(serialized_binast, offset);
+  offset = position.new_offset;
+
+  auto bit_field = DeserializeUint32(serialized_binast, offset);
+  offset = bit_field.new_offset;
+
+  bool is_resolved = VariableProxy::IsResolvedField::decode(bit_field.value);
+
+  VariableProxy* result;
+  if (is_resolved) {
+    // The resolved Variable should either be a reference (i.e. currently visible in scope) or should be a 
+    // NonScope Variable definition (i.e. it's a Variable that is outside the current Scope boundaries, 
+    // e.g. inside an eval).
+    auto variable = DeserializeNonScopeVariableOrReference(serialized_binast, offset);
+    offset = variable.new_offset;
+    result = parser_->factory()->NewVariableProxy(variable.value, position.value);
+  } else {
+    auto raw_name = DeserializeRawStringReference(serialized_binast, offset);
+    offset = raw_name.new_offset;
+    // We use NORMAL_VARIABLE as a placeholder here.
+    result = parser_->factory()->NewVariableProxy(raw_name.value, VariableKind::NORMAL_VARIABLE, position.value);
+  }
+  result->bit_field_ = bit_field.value;
+
+  auto next_unresolved_position = DeserializeInt32(serialized_binast, offset);
+  offset = next_unresolved_position.new_offset;
+
+  if (next_unresolved_position.value == -1) {
+    result->next_unresolved_ = nullptr;
+  } else {
+    result->next_unresolved_ = static_cast<VariableProxy*>(reinterpret_cast<void*>(next_unresolved_position.value));
+  }
+
+  DCHECK(variable_proxies_by_position_.count(position.value) == 0);
+  variable_proxies_by_position_[position.value] = result;
+
+  printf("\n  Deserialized a VariableProxy for Variable '%.*s'\n", result->raw_name()->byte_length(), result->raw_name()->raw_data());
+
+  return {result, offset};
+}
+
+BinAstDeserializer::DeserializeResult<VariableProxyExpression*> BinAstDeserializer::DeserializeVariableProxyExpression(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset) {
+  auto variable_proxy = DeserializeVariableProxy(serialized_binast, offset);
+  offset = variable_proxy.new_offset;
+
+  VariableProxyExpression* result = parser_->factory()->NewVariableProxyExpression(variable_proxy.value);
   result->bit_field_ = bit_field;
   return {result, offset};
 }

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -49,9 +49,11 @@ class BinAstDeserializer {
 
   DeserializeResult<Variable*> DeserializeLocalVariable(ByteArray serialized_binast, int offset, Scope* scope);
   DeserializeResult<Variable*> DeserializeNonLocalVariable(ByteArray serialized_binast, int offset, Scope* scope);
-  DeserializeResult<Variable*> DeserializeScopeVariableReference(ByteArray serialized_binast, int offset, Scope* scope);
+  DeserializeResult<Variable*> DeserializeVariableReference(ByteArray serialized_binast, int offset);
   DeserializeResult<Variable*> DeserializeScopeVariable(ByteArray serialized_binast, int offset, Scope* scope);
+  DeserializeResult<Variable*> DeserializeNonScopeVariable(ByteArray serialized_binast, int offset);
   DeserializeResult<Variable*> DeserializeScopeVariableOrReference(ByteArray serialized_binast, int offset, Scope* scope);
+  DeserializeResult<Variable*> DeserializeNonScopeVariableOrReference(ByteArray serialized_binast, int offset);
   DeserializeResult<std::nullptr_t> DeserializeScopeVariableMap(ByteArray serialized_binast, int offset, Scope* scope);
   DeserializeResult<Declaration*> DeserializeDeclaration(ByteArray serialized_binast, int offset, Scope* scope);
   DeserializeResult<std::nullptr_t> DeserializeScopeDeclarations(ByteArray serialized_binast, int offset, Scope* scope);
@@ -63,11 +65,17 @@ class BinAstDeserializer {
   DeserializeResult<ReturnStatement*> DeserializeReturnStatement(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<BinaryOperation*> DeserializeBinaryOperation(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<Property*> DeserializeProperty(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset);
+  DeserializeResult<ExpressionStatement*> DeserializeExpressionStatement(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset);
+  DeserializeResult<VariableProxy*> DeserializeVariableProxy(ByteArray serialized_binast, int offset);
+  DeserializeResult<VariableProxyExpression*> DeserializeVariableProxyExpression(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<std::nullptr_t> DeserializeNodeStub(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset);
+
+  void LinkUnresolvedVariableProxies();
 
   Parser* parser_;
   std::unordered_map<uint32_t, const AstRawString*> string_table_;
-  std::unordered_map<Scope*, std::unordered_map<uint32_t, Variable*>> variables_by_scope_;
+  std::unordered_map<uint32_t, Variable*> variables_by_id_;
+  std::unordered_map<uint32_t, VariableProxy*> variable_proxies_by_position_;
 };
 
 }  // namespace internal

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -58,21 +58,21 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   void SerializeRawStringReference(const AstRawString* s);
   void SerializeStringTable(const AstConsString* function_name);
   void SerializeVariable(Variable* variable);
-  void SerializeScopeVariable(Scope* scope, Variable* variable);
-  void SerializeScopeVariableReference(Scope* scope, Variable* variable);
-  void SerializeScopeVariableOrReference(Scope* scope, Variable* variable);
+  void SerializeVariableReference(Variable* variable);
+  void SerializeVariableOrReference(Variable* variable);
   void SerializeScopeVariableMap(Scope* scope);
   void SerializeDeclaration(Scope* scope, Declaration* decl);
   void SerializeScopeDeclarations(Scope* scope);
   void SerializeScopeParameters(DeclarationScope* scope);
   void SerializeDeclarationScope(DeclarationScope* scope);
   void SerializeAstNodeHeader(AstNode* node);
-
+  void SerializeVariableProxy(VariableProxy* proxy);
 
   AstValueFactory* ast_value_factory_;
   std::unordered_map<const AstRawString*, uint32_t> string_table_indices_;
   std::vector<uint8_t> byte_data_;
-  std::unordered_map<Scope*, std::unordered_map<Variable*, uint32_t>> vars_by_scope_;
+  std::unordered_map<Variable*, uint32_t> variable_ids_;
+  std::unordered_map<VariableProxy*, int> var_proxy_ids;
 };
 
 inline void BinAstSerializeVisitor::SerializeUint32(uint32_t value) {
@@ -238,19 +238,18 @@ inline void BinAstSerializeVisitor::SerializeVariable(Variable* variable) {
   SerializeInt32(variable->index());
   SerializeInt32(variable->initializer_position());
   SerializeUint16(variable->bit_field_);
+
+  DCHECK(variable_ids_.count(variable) == 0);
+  variable_ids_.insert({variable, variable_ids_.size() + 1});
 }
 
-inline void BinAstSerializeVisitor::SerializeScopeVariableReference(Scope* scope, Variable* variable) {
+inline void BinAstSerializeVisitor::SerializeVariableReference(Variable* variable) {
   if (variable == nullptr) {
     SerializeUint32(0);
     return;
   }
-  auto scope_var_ids_result = vars_by_scope_.find(scope);
-  DCHECK(scope_var_ids_result != vars_by_scope_.end());
-  std::unordered_map<Variable*, uint32_t>& scope_var_ids = scope_var_ids_result->second;
-
-  auto var_id_result = scope_var_ids.find(variable);
-  DCHECK(var_id_result != scope_var_ids.end());
+  auto var_id_result = variable_ids_.find(variable);
+  DCHECK(var_id_result != variable_ids_.end());
   uint32_t var_id = var_id_result->second;
   SerializeUint32(var_id);
 }
@@ -262,16 +261,12 @@ inline void BinAstSerializeVisitor::SerializeScopeVariableMap(Scope* scope) {
     locals.insert(variable->raw_name());
   }
 
-  DCHECK(vars_by_scope_.count(scope) == 0);
-  vars_by_scope_.insert({scope, std::unordered_map<Variable*, uint32_t>()});
-  std::unordered_map<Variable*, uint32_t>& var_ids = vars_by_scope_[scope];
-
   DCHECK(locals.size() < UINT32_MAX);
   uint32_t total_local_vars = static_cast<uint32_t>(locals.size());
   SerializeUint32(total_local_vars);
   for (Variable* variable : scope->locals_) {
     SerializeVariable(variable);
-    var_ids.insert({variable, var_ids.size() + 1});
+
   }
 
   // Now serialize any remaining variables we missed
@@ -282,7 +277,6 @@ inline void BinAstSerializeVisitor::SerializeScopeVariableMap(Scope* scope) {
     Variable* variable = reinterpret_cast<Variable*>(entry->value);
     if (locals.count(variable->raw_name()) == 0) {
       SerializeVariable(variable);
-      var_ids.insert({variable, var_ids.size() + 1});
       serialized_nonlocal_vars += 1;
     }
   }
@@ -292,7 +286,7 @@ inline void BinAstSerializeVisitor::SerializeScopeVariableMap(Scope* scope) {
 inline void BinAstSerializeVisitor::SerializeDeclaration(Scope* scope, Declaration* decl) {
   SerializeInt32(decl->position());
   SerializeUint8(decl->type());
-  SerializeScopeVariableReference(scope, decl->var());
+  SerializeVariableReference(decl->var());
 }
 
 inline void BinAstSerializeVisitor::SerializeScopeDeclarations(Scope* scope) {
@@ -313,30 +307,24 @@ inline void BinAstSerializeVisitor::SerializeScopeParameters(DeclarationScope* s
   SerializeInt32(scope->num_parameters());
 
   for (Variable* variable : scope->params_) {
-    SerializeScopeVariableReference(scope, variable);
+    SerializeVariableReference(variable);
   }
 }
 
-inline void BinAstSerializeVisitor::SerializeScopeVariable(Scope* scope, Variable* variable) {
-  SerializeVariable(variable);
-  auto& vars_in_scope = vars_by_scope_[scope];
-  DCHECK(vars_in_scope.count(variable) == 0);
-  vars_in_scope.insert({variable, vars_in_scope.size() + 1});
-}
-
-inline void BinAstSerializeVisitor::SerializeScopeVariableOrReference(Scope* scope, Variable* variable) {
+// Note: This could be deserialized as a Scoped or Non-scoped Variable depending on the context.
+inline void BinAstSerializeVisitor::SerializeVariableOrReference(Variable* variable) {
   if (variable == nullptr) {
     SerializeUint8(ScopeVariableKind::Null);
     return;
   }
 
-  auto& vars_in_scope = vars_by_scope_[scope];
-  if (vars_in_scope.count(variable) == 0) {
+  if (variable_ids_.count(variable) == 0) {
     SerializeUint8(ScopeVariableKind::Definition);
-    SerializeScopeVariable(scope, variable);
+    SerializeVariable(variable);
   } else {
+    DCHECK(variable->scope() != nullptr);
     SerializeUint8(ScopeVariableKind::Reference);
-    SerializeScopeVariableReference(scope, variable);
+    SerializeVariableReference(variable);
   }
 }
 
@@ -393,10 +381,10 @@ inline void BinAstSerializeVisitor::SerializeDeclarationScope(DeclarationScope* 
   // TODO(binast): sloppy_block_functions_ (needed for non-strict mode support)
   DCHECK(scope->sloppy_block_functions_.is_empty());
 
-  SerializeScopeVariableOrReference(scope, scope->receiver_);
-  SerializeScopeVariableOrReference(scope, scope->function_);
-  SerializeScopeVariableOrReference(scope, scope->new_target_);
-  SerializeScopeVariableOrReference(scope, scope->arguments_);
+  SerializeVariableOrReference(scope->receiver_);
+  SerializeVariableOrReference(scope->function_);
+  SerializeVariableOrReference(scope->new_target_);
+  SerializeVariableOrReference(scope->arguments_);
 
   // TODO(binast): rare_data_ (needed for > ES5.1 feature support)
   DCHECK(scope->rare_data_ == nullptr);
@@ -405,6 +393,48 @@ inline void BinAstSerializeVisitor::SerializeDeclarationScope(DeclarationScope* 
 inline void BinAstSerializeVisitor::SerializeAstNodeHeader(AstNode* node) {
   SerializeUint32(node->bit_field_);
   SerializeInt32(node->position_);
+}
+
+inline void BinAstSerializeVisitor::SerializeVariableProxy(VariableProxy* proxy) {
+  SerializeInt32(proxy->position());
+  SerializeUint32(proxy->bit_field_);
+  if (proxy->is_resolved()) {
+    SerializeVariableOrReference(proxy->var());
+  } else {
+    SerializeRawStringReference(proxy->raw_name());
+  }
+
+  // We need to be able to reproduce this chain of unresolved variable proxies,
+  // so we store all encountered VariableProxy objects in a map with their start
+  // positions, which should be unique per variable. We can then use this information
+  // during deserialization to link all of the VariableProxy objects.
+  if (proxy->next_unresolved_ == nullptr) {
+    // There is no next unresolved proxy, so store -1 which is an impossible start position.
+    SerializeInt32(-1);
+  } else {
+    // There is a next unresolved proxy, so look it up and add it if necessary.
+    int next_unresolved_position;
+    auto lookup_result = var_proxy_ids.find(proxy->next_unresolved_);
+    if (lookup_result == var_proxy_ids.end()) {
+      next_unresolved_position = proxy->next_unresolved_->position();
+      var_proxy_ids[proxy->next_unresolved_] = next_unresolved_position;
+    } else {
+      next_unresolved_position = lookup_result->second;
+    }
+    SerializeInt32(next_unresolved_position);
+  }
+  // Also insert ourself into the VariableProxy map if necessary.
+  auto lookup_result = var_proxy_ids.find(proxy);
+  if (lookup_result == var_proxy_ids.end()) {
+    var_proxy_ids[proxy] = proxy->position();
+  }
+
+  printf("\n  Serialized a VariableProxy for Variable '%.*s'\n", proxy->raw_name()->byte_length(), proxy->raw_name()->raw_data());
+}
+
+inline void ToDoBinAst() {
+  // TODO(binast): Delete this function when it's no longer needed.
+  // UNREACHABLE();
 }
 
 inline void BinAstSerializeVisitor::VisitFunctionLiteral(FunctionLiteral* function_literal) {
@@ -428,57 +458,57 @@ inline void BinAstSerializeVisitor::VisitFunctionLiteral(FunctionLiteral* functi
 
 inline void BinAstSerializeVisitor::VisitBlock(Block* block) {
   SerializeAstNodeHeader(block);
-  // TODO(binast)
+  ToDoBinAst();
 }
 
 inline void BinAstSerializeVisitor::VisitIfStatement(IfStatement* if_statement) {
   SerializeAstNodeHeader(if_statement);
-  // TODO(binast)
+  ToDoBinAst();
 }
 
 inline void BinAstSerializeVisitor::VisitExpressionStatement(ExpressionStatement* statement) {
   SerializeAstNodeHeader(statement);
-  // TODO(binast)
+  VisitNode(statement->expression());
 }
 
 inline void BinAstSerializeVisitor::VisitLiteral(Literal* literal) {
   SerializeAstNodeHeader(literal);
-  // TODO(binast)
+  ToDoBinAst();
 }
 
 inline void BinAstSerializeVisitor::VisitEmptyStatement(EmptyStatement* empty_statement) {
   SerializeAstNodeHeader(empty_statement);
-  // TODO(binast)
+  ToDoBinAst();
 }
 
 inline void BinAstSerializeVisitor::VisitAssignment(Assignment* assignment) {
   SerializeAstNodeHeader(assignment);
-  // TODO(binast)
+  ToDoBinAst();
 }
 
-inline void BinAstSerializeVisitor::VisitVariableProxyExpression(VariableProxyExpression* var_proxy) {
-  SerializeAstNodeHeader(var_proxy);
-  // TODO(binast)
+inline void BinAstSerializeVisitor::VisitVariableProxyExpression(VariableProxyExpression* var_proxy_expr) {
+  SerializeAstNodeHeader(var_proxy_expr);
+  SerializeVariableProxy(var_proxy_expr->proxy_);
 }
 
 inline void BinAstSerializeVisitor::VisitForStatement(ForStatement* for_statement) {
   SerializeAstNodeHeader(for_statement);
-  // TODO(binast)
+  ToDoBinAst();
 }
 
 inline void BinAstSerializeVisitor::VisitCompareOperation(CompareOperation* compare) {
   SerializeAstNodeHeader(compare);
-  // TODO(binast)
+  ToDoBinAst();
 }
 
 inline void BinAstSerializeVisitor::VisitCountOperation(CountOperation* operation) {
   SerializeAstNodeHeader(operation);
-  // TODO(binast)
+  ToDoBinAst();
 }
 
 inline void BinAstSerializeVisitor::VisitCall(Call* call) {
   SerializeAstNodeHeader(call);
-  // TODO(binast)
+  ToDoBinAst();
 }
 
 inline void BinAstSerializeVisitor::VisitProperty(Property* property) {
@@ -501,12 +531,12 @@ inline void BinAstSerializeVisitor::VisitBinaryOperation(BinaryOperation* binary
 
 inline void BinAstSerializeVisitor::VisitObjectLiteral(ObjectLiteral* object_literal) {
   SerializeAstNodeHeader(object_literal);
-  // TODO(binast)
+  ToDoBinAst();
 }
 
 inline void BinAstSerializeVisitor::VisitArrayLiteral(ArrayLiteral* array_literal) {
   SerializeAstNodeHeader(array_literal);
-  // TODO(binast)
+  ToDoBinAst();
 }
 
 }  // namespace internal


### PR DESCRIPTION
…yExpression

ExpressionStatement is pretty straightforward. VariableProxyExpression (and
VariableProxies along with them) required some reworking of how we handle Variables.
Originally we were storing a nested map of Variables and their IDs by Scope.
This actually served little purpose during the process of de/serialization, so this
diff removes that first layer, so now all Variable/ID pairs are stored in a single
pool during de/serialization. This allows us to deserialize Variable definitions that
aren't tied to any particular Scope (i.e. var->scope() == nullptr), which was required
for VariableProxy objects that referenced resolved Variables. If there was a non-null
Scope in the Variable, then that Scope's Variable declarations should already have been
processed and its Variables should already live in the pool, thus only requiring a reference.
However, if the Variable did not belong to any known Scope (as is often the case with
eval-ed scripts), we would need to define a new Variable in place which was not bound
to any Scope.

Another aspect of this diff is rebuilding the chain of unresolved VariableProxies.
We needed to be able to encode a way to reference the other VariableProxy objects.
To make things simple we use the position of the VariableProxy in the source as a
unique way to refer to it. Because we may not have de/serialized all VariableProxies
by the time we encounter them via the unresolved chain, we needed to separate the
linking of the unresolved chain from the deserialization of the individual VariableProxies.