### PR TITLE
Add de/serialization support for Literal AST nodes

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1137,6 +1137,8 @@ class Literal final : public Expression {
 
  private:
   friend class AstNodeFactory;
+  friend class BinAstSerializeVisitor;
+  friend class BinAstDeserializer;
 
   using TypeField = Expression::NextBitField<Type, 4>;
 

--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -23,6 +23,18 @@ Zone* BinAstDeserializer::zone() {
   return parser_->zone();
 }
 
+// TODO(binast): Use templates to de-dupe some of these functions.
+BinAstDeserializer::DeserializeResult<uint64_t> BinAstDeserializer::DeserializeUint64(ByteArray bytes, int offset) {
+  uint64_t result = 0;
+  for (int i = 0; i < 8; ++i) {
+    size_t shift = sizeof(uint8_t) * 8 * i;
+    uint64_t unshifted_value = bytes.get(offset + i);
+    uint64_t shifted_value = unshifted_value << shift;
+    result |= shifted_value;
+  }
+  return {result, offset + sizeof(uint64_t)};
+}
+
 BinAstDeserializer::DeserializeResult<uint32_t> BinAstDeserializer::DeserializeUint32(ByteArray bytes, int offset) {
   uint32_t result = 0;
   for (int i = 0; i < 4; ++i) {
@@ -70,6 +82,35 @@ BinAstDeserializer::DeserializeResult<int32_t> BinAstDeserializer::DeserializeIn
     result |= shifted_value;
   }
   return {result, offset + sizeof(int32_t)};
+}
+
+BinAstDeserializer::DeserializeResult<double> BinAstDeserializer::DeserializeDouble(ByteArray bytes, int offset) {
+  union {
+    double d;
+    uint64_t ui;
+  } converter;
+
+  auto result = DeserializeUint64(bytes, offset);
+  offset = result.new_offset;
+  converter.ui = result.value;
+  return {converter.d, offset};
+}
+
+BinAstDeserializer::DeserializeResult<const char*> BinAstDeserializer::DeserializeCString(ByteArray bytes, int offset) {
+  std::vector<char> characters;
+  for (int i = 0; ; ++i) {
+    auto next_char = DeserializeUint8(bytes, offset);
+    offset = next_char.new_offset;
+    char c = next_char.value;
+    characters.push_back(c);
+    if (c == 0) {
+      break;
+    }
+  }
+  char* result = zone()->NewArray<char>(characters.size());
+  DCHECK(characters.size() > 0);
+  memcpy(result, &characters[0], characters.size());
+  return {result, offset};
 }
 
 BinAstDeserializer::DeserializeResult<const AstRawString*> BinAstDeserializer::DeserializeRawString(ByteArray serialized_ast, int offset) {
@@ -201,9 +242,12 @@ BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::DeserializeA
     auto result = DeserializeVariableProxyExpression(serialized_binast, bit_field.value, position.value, offset);
     return {result.value, result.new_offset};
   }
+  case AstNode::kLiteral: {
+    auto result = DeserializeLiteral(serialized_binast, bit_field.value, position.value, offset);
+    return {result.value, result.new_offset};
+  }
   case AstNode::kBlock:
   case AstNode::kIfStatement:
-  case AstNode::kLiteral:
   case AstNode::kEmptyStatement:
   case AstNode::kAssignment:
   case AstNode::kForStatement:
@@ -732,8 +776,6 @@ BinAstDeserializer::DeserializeResult<VariableProxy*> BinAstDeserializer::Deseri
   DCHECK(variable_proxies_by_position_.count(position.value) == 0);
   variable_proxies_by_position_[position.value] = result;
 
-  printf("\n  Deserialized a VariableProxy for Variable '%.*s'\n", result->raw_name()->byte_length(), result->raw_name()->raw_data());
-
   return {result, offset};
 }
 
@@ -743,6 +785,68 @@ BinAstDeserializer::DeserializeResult<VariableProxyExpression*> BinAstDeserializ
 
   VariableProxyExpression* result = parser_->factory()->NewVariableProxyExpression(variable_proxy.value);
   result->bit_field_ = bit_field;
+  return {result, offset};
+}
+
+BinAstDeserializer::DeserializeResult<Literal*> BinAstDeserializer::DeserializeLiteral(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset) {
+  Literal::Type type = Literal::TypeField::decode(bit_field);
+
+  Literal* result;
+  switch (type) {
+    case Literal::kSmi: {
+      auto smi = DeserializeInt32(serialized_binast, offset);
+      offset = smi.new_offset;
+      result = parser_->factory()->NewSmiLiteral(smi.value, position);
+      break;
+    }
+    case Literal::kHeapNumber: {
+      auto number = DeserializeDouble(serialized_binast, offset);
+      offset = number.new_offset;
+      result = parser_->factory()->NewNumberLiteral(number.value, position);
+      break;
+    }
+    case Literal::kBigInt: {
+      auto bigint_str = DeserializeCString(serialized_binast, offset);
+      offset = bigint_str.new_offset;
+      result = parser_->factory()->NewBigIntLiteral(AstBigInt(bigint_str.value), position);
+      break;
+    }
+    case Literal::kString: {
+      auto string = DeserializeRawStringReference(serialized_binast, offset);
+      offset = string.new_offset;
+      result = parser_->factory()->NewStringLiteral(string.value, position);
+      break;
+    }
+    case Literal::kSymbol: {
+      auto symbol = DeserializeUint8(serialized_binast, offset);
+      offset = symbol.new_offset;
+      result = parser_->factory()->NewSymbolLiteral(static_cast<AstSymbol>(symbol.value), position);
+      break;
+    }
+    case Literal::kBoolean: {
+      auto boolean = DeserializeUint8(serialized_binast, position);
+      offset = boolean.new_offset;
+      result = parser_->factory()->NewBooleanLiteral(boolean.value, position);
+      break;
+    }
+    case Literal::kUndefined: {
+      result = parser_->factory()->NewUndefinedLiteral(position);
+      break;
+    }
+    case Literal::kNull: {
+      result = parser_->factory()->NewNullLiteral(position);
+      break;
+    }
+    case Literal::kTheHole: {
+      result = parser_->factory()->NewTheHoleLiteral();
+      break;
+    }
+    default: {
+      UNREACHABLE();
+    }
+  }
+  DCHECK(result->bit_field_ == bit_field);
+
   return {result, offset};
 }
 

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -35,12 +35,16 @@ class BinAstDeserializer {
   };
 
   Zone* zone();
+
+  DeserializeResult<uint64_t> DeserializeUint64(ByteArray bytes, int offset);
   DeserializeResult<uint32_t> DeserializeUint32(ByteArray bytes, int offset);
   DeserializeResult<uint16_t> DeserializeUint16(ByteArray bytes, int offset);
   DeserializeResult<uint8_t> DeserializeUint8(ByteArray bytes, int offset);
   DeserializeResult<int32_t> DeserializeInt32(ByteArray bytes, int offset);
   DeserializeResult<std::array<bool, 16>> DeserializeUint16Flags(ByteArray bytes, int offset);
+  DeserializeResult<double> DeserializeDouble(ByteArray bytes, int offset);
 
+  DeserializeResult<const char*> DeserializeCString(ByteArray bytes, int offset);
   DeserializeResult<const AstRawString*> DeserializeRawString(ByteArray bytes, int offset);
   DeserializeResult<std::nullptr_t> DeserializeStringTable(ByteArray bytes, int offset);
   DeserializeResult<const AstRawString*> DeserializeRawStringReference(ByteArray bytes, int offset);
@@ -67,6 +71,7 @@ class BinAstDeserializer {
   DeserializeResult<ExpressionStatement*> DeserializeExpressionStatement(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<VariableProxy*> DeserializeVariableProxy(ByteArray serialized_binast, int offset);
   DeserializeResult<VariableProxyExpression*> DeserializeVariableProxyExpression(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset);
+  DeserializeResult<Literal*> DeserializeLiteral(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<std::nullptr_t> DeserializeNodeStub(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset);
 
   void LinkUnresolvedVariableProxies();

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -48,11 +48,14 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   virtual void VisitArrayLiteral(ArrayLiteral *array_literal) override;
 
  private:
-  void SerializeUint32(uint32_t value);
+  void SerializeUint8(uint8_t value);
   void SerializeUint16(uint16_t value);
   void SerializeUint16Flags(const std::list<bool>& flags);
+  void SerializeUint32(uint32_t value);
+  void SerializeUint64(uint64_t value);
   void SerializeInt32(int32_t value);
-  void SerializeUint8(uint8_t value);
+  void SerializeDouble(double value);
+  void SerializeCString(const char* str);
   void SerializeRawString(const AstRawString* s);
   void SerializeConsString(const AstConsString* cons_string);
   void SerializeRawStringReference(const AstRawString* s);
@@ -74,6 +77,19 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   std::unordered_map<Variable*, uint32_t> variable_ids_;
   std::unordered_map<VariableProxy*, int> var_proxy_ids;
 };
+
+// TODO(binast): Maybe templatize these to reduce duplication?
+inline void BinAstSerializeVisitor::SerializeUint64(uint64_t value) {
+    for (size_t i = 0; i < sizeof(uint64_t) / sizeof(uint8_t); ++i) {
+    size_t shift = sizeof(uint8_t) * 8 * i;
+    uint64_t mask = 0xff << shift;
+    uint64_t masked_value = value & mask;
+    uint64_t final_value = masked_value >> shift;
+    DCHECK(final_value <= 0xff);
+    uint8_t truncated_final_value = final_value;
+    byte_data_.push_back(truncated_final_value);
+  }
+}
 
 inline void BinAstSerializeVisitor::SerializeUint32(uint32_t value) {
   for (size_t i = 0; i < sizeof(uint32_t) / sizeof(uint8_t); ++i) {
@@ -130,6 +146,26 @@ inline void BinAstSerializeVisitor::SerializeInt32(int32_t value) {
     DCHECK(final_value <= 0xff);
     uint8_t truncated_final_value = final_value;
     byte_data_.push_back(truncated_final_value);
+  }
+}
+
+inline void BinAstSerializeVisitor::SerializeDouble(double value) {
+  union {
+    double d;
+    uint64_t ui;
+  } converter;
+  converter.d = value;
+  SerializeUint64(converter.ui);
+}
+
+// Note: Assumes the provided char string is null-terminated
+inline void BinAstSerializeVisitor::SerializeCString(const char* str) {
+  for (int i = 0;; i++) {
+    char c = str[i];
+    if (c == 0) {
+      break;
+    }
+    SerializeUint8(c);
   }
 }
 
@@ -428,8 +464,6 @@ inline void BinAstSerializeVisitor::SerializeVariableProxy(VariableProxy* proxy)
   if (lookup_result == var_proxy_ids.end()) {
     var_proxy_ids[proxy] = proxy->position();
   }
-
-  printf("\n  Serialized a VariableProxy for Variable '%.*s'\n", proxy->raw_name()->byte_length(), proxy->raw_name()->raw_data());
 }
 
 inline void ToDoBinAst() {
@@ -473,7 +507,40 @@ inline void BinAstSerializeVisitor::VisitExpressionStatement(ExpressionStatement
 
 inline void BinAstSerializeVisitor::VisitLiteral(Literal* literal) {
   SerializeAstNodeHeader(literal);
-  ToDoBinAst();
+  switch(literal->type()) {
+    case Literal::kSmi: {
+      SerializeInt32(literal->smi_);
+      break;
+    }
+    case Literal::kHeapNumber: {
+      SerializeDouble(literal->number_);
+      break;
+    }
+    case Literal::kBigInt: {
+      SerializeCString(literal->bigint_.c_str());
+      break;
+    }
+    case Literal::kString: {
+      SerializeRawStringReference(literal->string_);
+      break;
+    }
+    case Literal::kSymbol: {
+      SerializeUint8(static_cast<uint8_t>(literal->symbol_));
+      break;
+    }
+    case Literal::kBoolean: {
+      SerializeUint8(literal->boolean_);
+      break;
+    }
+    case Literal::kUndefined:
+    case Literal::kNull:
+    case Literal::kTheHole: {
+      break;
+    }
+    default: {
+      UNREACHABLE();
+    }
+  }
 }
 
 inline void BinAstSerializeVisitor::VisitEmptyStatement(EmptyStatement* empty_statement) {


### PR DESCRIPTION
This was relatively straightforward--just check the type and perform the
appropriate de/serialization for the contents.