### PR TITLE
Add de/serialization for Call, IfStatement, and Block AST nodes

### DIFF
--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -193,8 +193,14 @@ void BinAstDeserializer::LinkUnresolvedVariableProxies() {
 
     int next_unresolved_position = (int)(std::intptr_t)var_proxy->next_unresolved_;
     auto lookup_result = variable_proxies_by_position_.find(next_unresolved_position);
-    DCHECK(lookup_result != variable_proxies_by_position_.end());
-    var_proxy->next_unresolved_ = lookup_result->second;
+    // TODO(binast): Enable this assert. We currently can't guarantee this since we don't support visiting all node types
+    // and therefore can't guarantee that we'll visit every VariableProxy.
+    // DCHECK(lookup_result != variable_proxies_by_position_.end());
+    if (lookup_result == variable_proxies_by_position_.end()) {
+      var_proxy->next_unresolved_ = nullptr;
+    } else {
+      var_proxy->next_unresolved_ = lookup_result->second;
+    }
   }
 }
 
@@ -246,14 +252,23 @@ BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::DeserializeA
     auto result = DeserializeLiteral(serialized_binast, bit_field.value, position.value, offset);
     return {result.value, result.new_offset};
   }
-  case AstNode::kBlock:
-  case AstNode::kIfStatement:
+  case AstNode::kCall: {
+    auto result = DeserializeCall(serialized_binast, bit_field.value, position.value, offset);
+    return {result.value, result.new_offset};
+  }
+  case AstNode::kIfStatement: {
+    auto result = DeserializeIfStatement(serialized_binast, bit_field.value, position.value, offset);
+    return {result.value, result.new_offset};
+  }
+  case AstNode::kBlock: {
+    auto result = DeserializeBlock(serialized_binast, bit_field.value, position.value, offset);
+    return {result.value, result.new_offset};
+  }
   case AstNode::kEmptyStatement:
   case AstNode::kAssignment:
   case AstNode::kForStatement:
   case AstNode::kCompareOperation:
   case AstNode::kCountOperation:
-  case AstNode::kCall:
   case AstNode::kObjectLiteral:
   case AstNode::kArrayLiteral: {
     auto result = DeserializeNodeStub(serialized_binast, bit_field.value, position.value, offset);
@@ -490,36 +505,7 @@ BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::Deseri
   return {nullptr, offset};
 }
 
-BinAstDeserializer::DeserializeResult<DeclarationScope*> BinAstDeserializer::DeserializeDeclarationScope(ByteArray serialized_binast, int offset) {
-  DeclarationScope* scope = nullptr;
-  auto scope_type = DeserializeUint8(serialized_binast, offset);
-  offset = scope_type.new_offset;
-
-  auto function_kind = DeserializeUint8(serialized_binast, offset);
-  offset = function_kind.new_offset;
-
-  switch (scope_type.value) {
-    case CLASS_SCOPE: 
-    case EVAL_SCOPE:
-    case MODULE_SCOPE:
-    case SCRIPT_SCOPE:
-    case CATCH_SCOPE:
-    case WITH_SCOPE: {
-      UNREACHABLE();
-    }
-    case FUNCTION_SCOPE: {
-      scope = parser_->NewFunctionScope(static_cast<FunctionKind>(function_kind.value));
-      break;
-    }
-    case BLOCK_SCOPE: {
-      scope = parser_->NewVarblockScope();
-      break;
-    }
-    default: {
-      UNREACHABLE();
-    }
-  }
-  DCHECK(scope_type.value == scope->scope_type());
+BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::DeserializeCommonScopeFields(ByteArray serialized_binast, int offset, Scope* scope) {
   // TODO(binast): How to represent/store these scope relationships?
   // Idea: We could store an ID with each scope when serializing it and then build a table of scopes as we deserialize and then link all the scopes in the tree together (similar to raw string references)
   // outer_scope_
@@ -581,6 +567,80 @@ BinAstDeserializer::DeserializeResult<DeclarationScope*> BinAstDeserializer::Des
   scope->must_use_preparsed_scope_data_ = encoded_boolean_flags_result.value[10];
   scope->is_repl_mode_scope_ = encoded_boolean_flags_result.value[11];
   scope->deserialized_scope_uses_external_cache_ = encoded_boolean_flags_result.value[12];
+
+  return {nullptr, offset};
+}
+
+BinAstDeserializer::DeserializeResult<Scope*> BinAstDeserializer::DeserializeScope(ByteArray serialized_binast, int offset) {
+  Scope* scope = nullptr;
+  auto scope_type = DeserializeUint8(serialized_binast, offset);
+  offset = scope_type.new_offset;
+
+  switch (scope_type.value) {
+    case FUNCTION_SCOPE:
+    case SCRIPT_SCOPE:
+    case MODULE_SCOPE: {
+      // Client should use the more specific version of this function.
+      UNREACHABLE();
+    }
+    case CLASS_SCOPE:
+    case EVAL_SCOPE:
+    case CATCH_SCOPE:
+    case WITH_SCOPE: {
+      // TODO(binast): Implement
+      DCHECK(false);
+      break;
+    }
+    case BLOCK_SCOPE: {
+      scope = parser_->NewVarblockScope();
+      break;
+    }
+    default: {
+      UNREACHABLE();
+    }
+  }
+  DCHECK(scope_type.value == scope->scope_type());
+
+  auto common_fields_result = DeserializeCommonScopeFields(serialized_binast, offset, scope);
+  offset = common_fields_result.new_offset;
+
+  return {scope, offset};
+}
+
+
+BinAstDeserializer::DeserializeResult<DeclarationScope*> BinAstDeserializer::DeserializeDeclarationScope(ByteArray serialized_binast, int offset) {
+  DeclarationScope* scope = nullptr;
+  auto scope_type = DeserializeUint8(serialized_binast, offset);
+  offset = scope_type.new_offset;
+
+  switch (scope_type.value) {
+    case CLASS_SCOPE: 
+    case EVAL_SCOPE:
+    case MODULE_SCOPE:
+    case SCRIPT_SCOPE:
+    case CATCH_SCOPE:
+    case WITH_SCOPE: {
+      UNREACHABLE();
+    }
+    case FUNCTION_SCOPE: {
+      auto function_kind = DeserializeUint8(serialized_binast, offset);
+      offset = function_kind.new_offset;
+
+      scope = parser_->NewFunctionScope(static_cast<FunctionKind>(function_kind.value));
+      break;
+    }
+    case BLOCK_SCOPE: {
+      scope = parser_->NewVarblockScope();
+      break;
+    }
+    default: {
+      UNREACHABLE();
+    }
+  }
+  DCHECK(scope_type.value == scope->scope_type());
+
+  auto common_fields_result = DeserializeCommonScopeFields(serialized_binast, offset, scope);
+  offset = common_fields_result.new_offset;
 
   // DeclarationScope data:
   auto encoded_decl_scope_bool_flags_result = DeserializeUint16Flags(serialized_binast, offset);
@@ -848,6 +908,71 @@ BinAstDeserializer::DeserializeResult<Literal*> BinAstDeserializer::DeserializeL
   DCHECK(result->bit_field_ == bit_field);
 
   return {result, offset};
+}
+
+BinAstDeserializer::DeserializeResult<Call*> BinAstDeserializer::DeserializeCall(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset) {
+  auto expression = DeserializeAstNode(serialized_binast, offset);
+  offset = expression.new_offset;
+
+  auto params_count = DeserializeInt32(serialized_binast, offset);
+  offset = params_count.new_offset;
+
+  std::vector<void*> pointer_buffer;
+  ScopedPtrList<Expression> params(&pointer_buffer);
+  for (int i = 0; i < params_count.value; ++i) {
+    auto param = DeserializeAstNode(serialized_binast, offset);
+    offset = param.new_offset;
+    params.Add(static_cast<Expression*>(param.value));
+  }
+
+  Call* result = parser_->factory()->NewCall(static_cast<Expression*>(expression.value), params, position);
+  result->bit_field_ = bit_field;
+  return {result, offset};
+}
+
+BinAstDeserializer::DeserializeResult<IfStatement*> BinAstDeserializer::DeserializeIfStatement(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset) {
+  auto condition = DeserializeAstNode(serialized_binast, offset);
+  offset = condition.new_offset;
+
+  auto then_statement = DeserializeAstNode(serialized_binast, offset);
+  offset = then_statement.new_offset;
+
+  auto else_statement = DeserializeAstNode(serialized_binast, offset);
+  offset = else_statement.new_offset;
+
+  IfStatement* result = parser_->factory()->NewIfStatement(static_cast<Expression*>(condition.value), static_cast<Statement*>(then_statement.value), static_cast<Statement*>(else_statement.value), position);
+  DCHECK(result->bit_field_ == bit_field);
+  return {result, offset};
+}
+
+BinAstDeserializer::DeserializeResult<Block*> BinAstDeserializer::DeserializeBlock(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset) {
+  auto statement_count = DeserializeInt32(serialized_binast, offset);
+  offset = statement_count.new_offset;
+
+  std::vector<void*> pointer_buffer;
+  ScopedPtrList<Statement> statements(&pointer_buffer);
+  for (int i = 0; i < statement_count.value; ++i) {
+    auto statement = DeserializeAstNode(serialized_binast, offset);
+    offset = statement.new_offset;
+    statements.Add(static_cast<Statement*>(statement.value));
+  }
+
+  auto has_scope = DeserializeUint8(serialized_binast, offset);
+  offset = has_scope.new_offset;
+
+  Scope* scope = nullptr;
+  if (has_scope.value) {
+    auto scope_result = DeserializeScope(serialized_binast, offset);
+    offset = scope_result.new_offset;
+    scope = scope_result.value;
+  }
+
+  bool ignore_completion_value = false; // Just a filler value.
+  Block* block = parser_->factory()->NewBlock(ignore_completion_value, statements);
+  block->bit_field_ = bit_field;
+  block->set_scope(scope);
+
+  return {nullptr, offset};
 }
 
 // This is just a placeholder while we implement the various nodes that we'll support.

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -62,6 +62,8 @@ class BinAstDeserializer {
   DeserializeResult<Declaration*> DeserializeDeclaration(ByteArray serialized_binast, int offset, Scope* scope);
   DeserializeResult<std::nullptr_t> DeserializeScopeDeclarations(ByteArray serialized_binast, int offset, Scope* scope);
   DeserializeResult<std::nullptr_t> DeserializeScopeParameters(ByteArray serialized_binast, int offset, DeclarationScope* scope);
+  DeserializeResult<std::nullptr_t> DeserializeCommonScopeFields(ByteArray serialized_binast, int offset, Scope* scope);
+  DeserializeResult<Scope*> DeserializeScope(ByteArray serialized_binast, int offset);
   DeserializeResult<DeclarationScope*> DeserializeDeclarationScope(ByteArray serialized_binast, int offset);
 
   DeserializeResult<AstNode*> DeserializeAstNode(ByteArray serialized_ast, int offset);
@@ -73,6 +75,9 @@ class BinAstDeserializer {
   DeserializeResult<VariableProxy*> DeserializeVariableProxy(ByteArray serialized_binast, int offset);
   DeserializeResult<VariableProxyExpression*> DeserializeVariableProxyExpression(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<Literal*> DeserializeLiteral(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset);
+  DeserializeResult<Call*> DeserializeCall(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset);
+  DeserializeResult<IfStatement*> DeserializeIfStatement(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset);
+  DeserializeResult<Block*> DeserializeBlock(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<std::nullptr_t> DeserializeNodeStub(ByteArray serialized_binast, uint32_t bit_field, int32_t position, int offset);
 
   void LinkUnresolvedVariableProxies();

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -67,6 +67,8 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   void SerializeDeclaration(Scope* scope, Declaration* decl);
   void SerializeScopeDeclarations(Scope* scope);
   void SerializeScopeParameters(DeclarationScope* scope);
+  void SerializeCommonScopeFields(Scope* scope);
+  void SerializeScope(Scope* scope);
   void SerializeDeclarationScope(DeclarationScope* scope);
   void SerializeAstNodeHeader(AstNode* node);
   void SerializeVariableProxy(VariableProxy* proxy);
@@ -364,10 +366,7 @@ inline void BinAstSerializeVisitor::SerializeVariableOrReference(Variable* varia
   }
 }
 
-inline void BinAstSerializeVisitor::SerializeDeclarationScope(DeclarationScope* scope) {
-  ScopeType scope_type = scope->scope_type();
-  SerializeUint8(scope_type);
-  SerializeUint8(scope->function_kind());
+inline void BinAstSerializeVisitor::SerializeCommonScopeFields(Scope* scope) {
   SerializeScopeVariableMap(scope);
   SerializeScopeDeclarations(scope);
 #ifdef DEBUG
@@ -395,6 +394,13 @@ inline void BinAstSerializeVisitor::SerializeDeclarationScope(DeclarationScope* 
     scope->is_repl_mode_scope_,
     scope->deserialized_scope_uses_external_cache_,
   });
+}
+
+inline void BinAstSerializeVisitor::SerializeDeclarationScope(DeclarationScope* scope) {
+  SerializeUint8(scope->scope_type());
+  DCHECK(scope->scope_type() == FUNCTION_SCOPE);
+  SerializeUint8(scope->function_kind());
+  SerializeCommonScopeFields(scope);
   // DeclarationScope-specific flags
   SerializeUint16Flags({
     scope->has_simple_parameters_,
@@ -424,6 +430,15 @@ inline void BinAstSerializeVisitor::SerializeDeclarationScope(DeclarationScope* 
 
   // TODO(binast): rare_data_ (needed for > ES5.1 feature support)
   DCHECK(scope->rare_data_ == nullptr);
+}
+
+inline void BinAstSerializeVisitor::SerializeScope(Scope* scope) {
+  ScopeType scope_type = scope->scope_type();
+  SerializeUint8(scope_type);
+  DCHECK(scope_type != FUNCTION_SCOPE);
+  DCHECK(scope_type != SCRIPT_SCOPE);
+  DCHECK(scope_type != MODULE_SCOPE);
+  SerializeCommonScopeFields(scope);
 }
 
 inline void BinAstSerializeVisitor::SerializeAstNodeHeader(AstNode* node) {
@@ -492,12 +507,23 @@ inline void BinAstSerializeVisitor::VisitFunctionLiteral(FunctionLiteral* functi
 
 inline void BinAstSerializeVisitor::VisitBlock(Block* block) {
   SerializeAstNodeHeader(block);
-  ToDoBinAst();
+  SerializeInt32(block->statements()->length());
+  for (Statement* statement : *block->statements()) {
+    VisitNode(statement);
+  }
+  if (block->scope()) {
+    SerializeUint8(1);
+    SerializeScope(block->scope());
+  } else {
+    SerializeUint8(0);
+  }
 }
 
 inline void BinAstSerializeVisitor::VisitIfStatement(IfStatement* if_statement) {
   SerializeAstNodeHeader(if_statement);
-  ToDoBinAst();
+  VisitNode(if_statement->condition());
+  VisitNode(if_statement->then_statement());
+  VisitNode(if_statement->else_statement());
 }
 
 inline void BinAstSerializeVisitor::VisitExpressionStatement(ExpressionStatement* statement) {
@@ -575,7 +601,11 @@ inline void BinAstSerializeVisitor::VisitCountOperation(CountOperation* operatio
 
 inline void BinAstSerializeVisitor::VisitCall(Call* call) {
   SerializeAstNodeHeader(call);
-  ToDoBinAst();
+  VisitNode(call->expression());
+  SerializeInt32(call->arguments()->length());
+  for (Expression* arg : *call->arguments()) {
+    VisitNode(arg);
+  }
 }
 
 inline void BinAstSerializeVisitor::VisitProperty(Property* property) {


### PR DESCRIPTION
IfStatement and Call were very straightforward. Block took some refactoring
so that we could serialize its corresponding Scope and reuse portions of the
logic from DeclarationScope.