### PR TITLE
remove duplicated code from BinAstParser

### DIFF
--- a/src/parsing/abstract-parser.h
+++ b/src/parsing/abstract-parser.h
@@ -1682,7 +1682,7 @@ void AbstractParser<Impl>::ParseProgram(
   FunctionLiteral* result = impl()->DoParseProgram(isolate, info);
   MaybeResetCharacterStream(info, result);
   MaybeProcessSourceRanges(info, result, impl()->stack_limit_);
-  PostProcessParseResult(isolate, info, result);
+  impl()->PostProcessParseResult(isolate, info, result);
 
   HandleSourceURLComments(isolate, script);
 
@@ -1847,7 +1847,6 @@ void AbstractParser<Impl>::PostProcessParseResult(Isolate* isolate,
 
   // We cannot internalize on a background thread; a foreground task will take
   // care of calling AstValueFactory::Internalize just before compilation.
-  DCHECK_EQ(isolate != nullptr, impl()->parsing_on_main_thread_);
   if (isolate) info->ast_value_factory()->Internalize(isolate);
 
   {
@@ -2059,7 +2058,7 @@ void AbstractParser<Impl>::ParseFunction(
     Handle<String> inferred_name(shared_info->inferred_name(), isolate);
     result->set_inferred_name(inferred_name);
   }
-  PostProcessParseResult(isolate, info, result);
+  impl()->PostProcessParseResult(isolate, info, result);
 
   if (V8_UNLIKELY(FLAG_log_function_events) && result != nullptr) {
     double ms = timer.Elapsed().InMillisecondsF();
@@ -2079,7 +2078,6 @@ template <typename Impl>
 FunctionLiteral* AbstractParser<Impl>::DoParseFunction(
     Isolate* isolate, ParseInfo* info, int start_position, int end_position,
     int function_literal_id, const AstRawString* raw_name) {
-  DCHECK_EQ(impl()->parsing_on_main_thread_, isolate != nullptr);
   DCHECK_NOT_NULL(raw_name);
   DCHECK_NULL(impl()->scope_);
 
@@ -2195,7 +2193,7 @@ FunctionLiteral* AbstractParser<Impl>::DoParseFunction(
           info->is_wrapped_as_function()
               ? PrepareWrappedArguments(isolate, info, impl()->zone())
               : nullptr;
-      result = ParseFunctionLiteral(
+      result = impl()->ParseFunctionLiteral(
           raw_name, Scanner::Location::invalid(), kSkipFunctionNameCheck, kind,
           kNoSourcePosition, impl()->flags().function_syntax_kind(),
           info->language_mode(), arguments_for_wrapped_function);
@@ -4534,15 +4532,15 @@ void AbstractParser<Impl>::ParseOnBackground(ParseInfo* info,
     DCHECK_EQ(start_position, 0);
     DCHECK_EQ(end_position, 0);
     DCHECK_EQ(function_literal_id, kFunctionLiteralIdTopLevel);
-    result = DoParseProgram(/* isolate = */ nullptr, info);
+    result = impl()->DoParseProgram(/* isolate = */ nullptr, info);
   } else {
-    result = DoParseFunction(/* isolate = */ nullptr, info, start_position,
+    result = impl()->DoParseFunction(/* isolate = */ nullptr, info, start_position,
                              end_position, function_literal_id,
                              info->function_name());
   }
   MaybeResetCharacterStream(info, result);
   MaybeProcessSourceRanges(info, result, impl()->stack_limit_);
-  PostProcessParseResult(/* isolate = */ nullptr, info, result);
+  impl()->PostProcessParseResult(/* isolate = */ nullptr, info, result);
 }
 
 template <typename Impl>

--- a/src/parsing/binast-parser.h
+++ b/src/parsing/binast-parser.h
@@ -29,17 +29,7 @@ class BinAstParser : public AbstractParser<BinAstParser> {
  public:
   explicit BinAstParser(ParseInfo* info);
 
-  // Sets the literal on |info| if parsing succeeded.
-  void ParseOnBackground(ParseInfo* info, int start_position, int end_position,
-                         int function_literal_id);
-
   void ParseProgram(ParseInfo* info);
-
-
-  FunctionLiteral* DoParseFunction(ParseInfo* info,
-                                   int start_position, int end_position,
-                                   int function_literal_id,
-                                   const AstRawString* raw_name);
 
  private:
   friend class AbstractParser<BinAstParser>;
@@ -49,61 +39,9 @@ class BinAstParser : public AbstractParser<BinAstParser> {
   friend class i::ParameterDeclarationParsingScope<ParserTypes<BinAstParser>>;
   friend class i::ArrowHeadParsingScope<ParserTypes<BinAstParser>>;
 
-  bool parse_lazily() const {
-    // TODO(binast)
-    return false;
-  }
-
-  FunctionLiteral* DoParseProgram(ParseInfo* info);
-  void PostProcessParseResult(ParseInfo* info, FunctionLiteral* literal);
-
-  void DeclareFunctionNameVar(const AstRawString* function_name,
-                              FunctionSyntaxKind function_syntax_kind,
-                              DeclarationScope* function_scope);
-
-  Statement* DeclareFunction(const AstRawString* variable_name,
-                             FunctionLiteral* function, VariableMode mode,
-                             VariableKind kind, int beg_pos, int end_pos,
-                             ZonePtrList<const AstRawString>* names);
-
-  void Declare(Declaration* declaration, const AstRawString* name,
-               VariableKind variable_kind, VariableMode mode, InitializationFlag init,
-               Scope* scope, bool* was_added, int var_begin_pos,
-               int var_end_pos = kNoSourcePosition)
-  {
-    bool local_ok = true;
-    bool sloppy_mode_block_scope_function_redefinition = false;
-    scope->DeclareVariable(
-        declaration, name, var_begin_pos, mode, variable_kind, init, was_added,
-        &sloppy_mode_block_scope_function_redefinition, &local_ok);
-    if (!local_ok) {
-      // If we only have the start position of a proxy, we can't highlight the
-      // whole variable name.  Pretend its length is 1 so that we highlight at
-      // least the first character.
-      Scanner::Location loc(var_begin_pos, var_end_pos != kNoSourcePosition
-                                              ? var_end_pos
-                                              : var_begin_pos + 1);
-      if (variable_kind == PARAMETER_VARIABLE) {
-        ReportMessageAt(loc, MessageTemplate::kParamDupe);
-      } else {
-        ReportMessageAt(loc, MessageTemplate::kVarRedeclaration,
-                        declaration->var()->raw_name());
-      }
-    } else if (sloppy_mode_block_scope_function_redefinition) {
-      // TODO(binast)
-      DCHECK(false);
-      // ++use_counts_[v8::Isolate::kSloppyModeBlockScopedFunctionRedefinition];
-    }
-  }
-
-  void ParseFunction(
-      ScopedPtrList<Statement>* body, const AstRawString* function_name,
-      int pos, FunctionKind kind, FunctionSyntaxKind function_syntax_kind,
-      DeclarationScope* function_scope, int* num_parameters,
-      int* function_length, bool* has_duplicate_parameters,
-      int* expected_property_count, int* suspend_count,
-      ZonePtrList<const AstRawString>* arguments_for_wrapped_function);
-
+  FunctionLiteral* DoParseProgram(Isolate* isolate, ParseInfo* info);
+  void PostProcessParseResult(Isolate* isolate, ParseInfo* info,
+                              FunctionLiteral* literal);
   FunctionLiteral* ParseFunctionLiteral(
     const AstRawString* name, Scanner::Location function_name_location,
     FunctionNameValidity function_name_validity, FunctionKind kind,

--- a/src/parsing/parser.h
+++ b/src/parsing/parser.h
@@ -11,13 +11,32 @@ namespace v8 {
 namespace internal {
 
 template <>
-struct ParserTypes<Parser> : AbstractParserTypes<Parser> {
-};
+struct ParserTypes<Parser> : AbstractParserTypes<Parser> {};
 
 class V8_EXPORT_PRIVATE Parser
     : public NON_EXPORTED_BASE(AbstractParser<Parser>) {
  public:
   Parser(ParseInfo* info) : AbstractParser<Parser>(info) {}
+
+ private:
+  friend class AbstractParser<Parser>;
+  
+  FunctionLiteral* DoParseFunction(Isolate* isolate, ParseInfo* info,
+                                   int start_position, int end_position,
+                                   int function_literal_id,
+                                   const AstRawString* raw_name) {
+    DCHECK_EQ(impl()->parsing_on_main_thread_, isolate != nullptr);
+
+    return AbstractParser<Parser>::DoParseFunction(
+        isolate, info, start_position, end_position, function_literal_id,
+        raw_name);
+  }
+
+  void PostProcessParseResult(Isolate* isolate, ParseInfo* info,
+                              FunctionLiteral* literal) {
+    DCHECK_EQ(isolate != nullptr, impl()->parsing_on_main_thread_);
+    AbstractParser<Parser>::PostProcessParseResult(isolate, info, literal);
+  }
 };
 
 }  // namespace internal

--- a/src/parsing/test_binast.cc
+++ b/src/parsing/test_binast.cc
@@ -8,7 +8,7 @@
 #include "src/ast/prettyprinter.h"
 
 static const char* test_scripts[] = {
-  // TODO(binast): (sloppy mode) "42",
+  "42",
   "'use strict';\n42",
   "'use strict';\n'foo'",
   "'use strict';\nif (true) { 'foo'; }",
@@ -20,6 +20,7 @@ static const char* test_scripts[] = {
   "'use strict';\nvar obj = {foo: 'bar', bar: 1, baz: function(x) { return x; }};",
   "'use strict';\nvar obj = {}; obj.foo = 'bar';",
   "'use strict';\nvar arr = [];",
+  "'use strict';\nconst square = (x) => x * x;",
 };
 
 static const size_t num_test_scripts = sizeof(test_scripts) / sizeof(char*);


### PR DESCRIPTION
removes unneeded overrides from BinAstParser: DoParseFunction, PostProcessParseResult, DeclareFunctionNameVar, DeclareFunction, ParseFunction, ParseOnBackground, parse_lazily, Declare

remaining overrides are ParseProgram, DoParseProgram, and ParseFunctionLiteral. these also have a fair amount of duplicated code against the base, but i don't think it's clear yet how best to dedupe that. seems less complicated to leave it overriding for the moment.