### PR TITLE
Don't de/serialize AstStringConstants

### DIFF
--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -220,6 +220,7 @@ inline void BinAstSerializeVisitor::SerializeConsString(const AstConsString* con
 
 inline void BinAstSerializeVisitor::SerializeStringTable(const AstConsString* function_name) {
   uint32_t num_entries = ast_value_factory_->string_table_.occupancy();
+  uint32_t num_constant_entries = ast_value_factory_->string_constants_->string_table()->occupancy();
   // We serialize the outer function raw_name too.
   // TODO(binast): Do we need to?
   if (function_name != nullptr) {
@@ -230,11 +231,24 @@ inline void BinAstSerializeVisitor::SerializeStringTable(const AstConsString* fu
       }
     }
   }
-  SerializeUint32(num_entries);
+  SerializeUint32(num_entries - num_constant_entries);
   uint32_t current_index = 1;
+  // Insert non-constant strings
   for (base::HashMap::Entry* entry = ast_value_factory_->string_table_.Start(); entry != nullptr; entry = ast_value_factory_->string_table_.Next(entry)) {
     const AstRawString* s = reinterpret_cast<const AstRawString*>(entry->key);
+    // We don't want to serialize string constants that are shared between Isolates
+    base::HashMap::Entry* string_const_entry = ast_value_factory_->string_constants_->string_table()->Lookup(const_cast<AstRawString*>(s), s->Hash());
+    if (string_const_entry != nullptr) {
+      continue;
+    }
     SerializeRawString(s);
+    string_table_indices_.insert({s, current_index});
+    current_index += 1;
+  }
+
+  // Only insert constant strings into the table (i.e. don't serialize their contents)
+  for (base::HashMap::Entry* entry = ast_value_factory_->string_constants_->string_table()->Start(); entry != nullptr; entry = ast_value_factory_->string_constants_->string_table()->Next(entry)) {
+    const AstRawString* s = reinterpret_cast<const AstRawString*>(entry->key);
     string_table_indices_.insert({s, current_index});
     current_index += 1;
   }

--- a/test/binast/test.js
+++ b/test/binast/test.js
@@ -2,6 +2,43 @@
 
 var double = function(x) { return x * 2; }
 function triple(x) { return x * 3; }
+function deep() {
+  return function() {
+    return function() {
+    return function() {
+    return function() {
+    return function() {
+    return function() {
+    return function() {
+    return function() {
+    return function() {
+    return function() {
+    return function() {
+    return function() {
+    return function() {
+    return function() {
+    return function() {
+    return function() {
+    return function() {
+      return 42;
+    };
+    };
+    };
+    };
+    };
+    };
+    };
+    };
+    };
+    };
+    };
+    };
+    };
+    };
+    };
+    };
+  };
+}
 
 var oldSetTimeout = setTimeout;
 var timerCallbacks = [];
@@ -51,6 +88,7 @@ setTimeout(function testCallback2() {
   console.log("running callback");
   console.log(double(42));
   console.log(triple(24));
+  console.log(deep()()()()()()()()()()()()()()()()()());
 }, 5000);
 
 tickRunLoop();


### PR DESCRIPTION
They're shared across Isolates, so there's no need to serialize them because
we can just re-insert them on the other side during deserialization. This
saves us a chunk of memory for each serialized function, which is especially
important for smaller functions.