### PR TITLE
Add ability to easily turn compression on/off

### DIFF
--- a/src/parsing/abstract-parser.h
+++ b/src/parsing/abstract-parser.h
@@ -2028,15 +2028,15 @@ void AbstractParser<Impl>::ParseFunction(
     auto elapsed = std::chrono::high_resolution_clock::now() - start;
     long long microseconds =
         std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
-    printf("Deserialized function literal for '");
+    printf("\nDeserialized function literal for '");
     if (literal->has_shared_name()) {
       for (const AstRawString* s : literal->raw_name()->ToRawStrings()) {
         printf("%.*s", s->byte_length(), s->raw_data());
       }
     }
-    printf("' in %lld us: %p\n", microseconds, literal);
+    printf("' in %lld us\n", microseconds);
     // TODO(binast): Store the literal on the ParseInfo
-    result = literal;
+    // result = literal;
   }
 
   if (V8_UNLIKELY(result == nullptr && shared_info->private_name_lookup_skips_outer_class() &&
@@ -2061,7 +2061,7 @@ void AbstractParser<Impl>::ParseFunction(
         printf("%.*s", s->byte_length(), s->raw_data());
       }
     }
-    printf("' in %lld us: %p\n", microseconds, result);
+    printf("' in %lld us\n", microseconds);
   }
   MaybeResetCharacterStream(info, result);
   MaybeProcessSourceRanges(info, result, impl()->stack_limit_);

--- a/src/parsing/binast-deserializer-inl.h
+++ b/src/parsing/binast-deserializer-inl.h
@@ -1,0 +1,414 @@
+// Copyright 2020 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef V8_PARSING_BINAST_DESERIALIZER_INL_H_
+#define V8_PARSING_BINAST_DESERIALIZER_INL_H_
+
+#include "src/parsing/binast-deserializer.h"
+#include "src/parsing/parser.h"
+#include "src/parsing/binast-serialize-visitor.h"
+
+namespace v8 {
+namespace internal {
+
+inline Zone* BinAstDeserializer::zone() {
+  return parser_->zone();
+}
+
+// TODO(binast): Use templates to de-dupe some of these functions.
+inline BinAstDeserializer::DeserializeResult<uint64_t> BinAstDeserializer::DeserializeUint64(uint8_t* bytes, int offset) {
+  uint64_t result = 0;
+  for (int i = 0; i < 8; ++i) {
+    size_t shift = sizeof(uint8_t) * 8 * i;
+    uint64_t unshifted_value = bytes[offset + i];
+    uint64_t shifted_value = unshifted_value << shift;
+    result |= shifted_value;
+  }
+  return {result, offset + sizeof(uint64_t)};
+}
+
+inline BinAstDeserializer::DeserializeResult<uint32_t> BinAstDeserializer::DeserializeUint32(uint8_t* bytes, int offset) {
+  uint32_t result = 0;
+  for (int i = 0; i < 4; ++i) {
+    size_t shift = sizeof(uint8_t) * 8 * i;
+    uint32_t unshifted_value = bytes[offset + i];
+    uint32_t shifted_value = unshifted_value << shift;
+    result |= shifted_value;
+  }
+  return {result, offset + sizeof(uint32_t)};
+}
+
+inline BinAstDeserializer::DeserializeResult<uint16_t> BinAstDeserializer::DeserializeUint16(uint8_t* bytes, int offset) {
+  uint16_t result = 0;
+  for (int i = 0; i < 2; ++i) {
+    size_t shift = sizeof(uint8_t) * 8 * i;
+    uint32_t unshifted_value = bytes[offset + i];
+    uint32_t shifted_value = unshifted_value << shift;
+    result |= shifted_value;
+  }
+  return {result, offset + sizeof(uint16_t)};
+}
+
+inline BinAstDeserializer::DeserializeResult<std::array<bool, 16>> BinAstDeserializer::DeserializeUint16Flags(uint8_t* bytes, int offset) {
+  std::array<bool, 16> flags;
+  auto encoded_flags_result = DeserializeUint16(bytes, offset);
+  offset = encoded_flags_result.new_offset;
+  uint16_t encoded_flags = encoded_flags_result.value;
+  for (size_t i = 0; i < flags.size(); ++i) {
+    auto shift = flags.size() - i - 1;
+    flags[i] = (encoded_flags >> shift) & 0x1;
+  }
+  return {flags, offset};
+}
+
+inline BinAstDeserializer::DeserializeResult<uint8_t> BinAstDeserializer::DeserializeUint8(uint8_t* bytes, int offset) {
+  return {bytes[offset], offset + sizeof(uint8_t)};
+}
+
+inline BinAstDeserializer::DeserializeResult<int32_t> BinAstDeserializer::DeserializeInt32(uint8_t* bytes, int offset) {
+  uint32_t result = 0;
+  for (int i = 0; i < 4; ++i) {
+    size_t shift = sizeof(uint8_t) * 8 * i;
+    uint32_t unshifted_value = bytes[offset + i];
+    uint32_t shifted_value = unshifted_value << shift;
+    result |= shifted_value;
+  }
+  return {result, offset + sizeof(int32_t)};
+}
+
+inline BinAstDeserializer::DeserializeResult<double> BinAstDeserializer::DeserializeDouble(uint8_t* bytes, int offset) {
+  union {
+    double d;
+    uint64_t ui;
+  } converter;
+
+  auto result = DeserializeUint64(bytes, offset);
+  offset = result.new_offset;
+  converter.ui = result.value;
+  return {converter.d, offset};
+}
+
+inline BinAstDeserializer::DeserializeResult<const char*> BinAstDeserializer::DeserializeCString(uint8_t* bytes, int offset) {
+  std::vector<char> characters;
+  for (int i = 0; ; ++i) {
+    auto next_char = DeserializeUint8(bytes, offset);
+    offset = next_char.new_offset;
+    char c = next_char.value;
+    characters.push_back(c);
+    if (c == 0) {
+      break;
+    }
+  }
+  char* result = zone()->NewArray<char>(characters.size());
+  DCHECK(characters.size() > 0);
+  memcpy(result, &characters[0], characters.size());
+  return {result, offset};
+}
+
+inline BinAstDeserializer::DeserializeResult<const AstRawString*> BinAstDeserializer::DeserializeRawString(uint8_t* serialized_ast, int offset) {
+  auto is_one_byte = DeserializeUint8(serialized_ast, offset);
+  offset = is_one_byte.new_offset;
+
+  auto hash_field = DeserializeUint32(serialized_ast, offset);
+  offset = hash_field.new_offset;
+
+  auto length = DeserializeUint32(serialized_ast, offset);
+  offset = length.new_offset;
+
+  std::vector<uint8_t> raw_data;
+  for (uint32_t i = 0; i < length.value; ++i) {
+    auto next_byte = DeserializeUint8(serialized_ast, offset);
+    offset = next_byte.new_offset;
+    raw_data.push_back(next_byte.value);
+  }
+  const AstRawString* s = nullptr;
+  if (raw_data.size() > 0) {
+    Vector<const byte> literal_bytes(&raw_data[0], raw_data.size());
+    s = parser_->ast_value_factory()->GetString(hash_field.value, is_one_byte.value, literal_bytes);
+  } else {
+    Vector<const byte> literal_bytes;
+    s = parser_->ast_value_factory()->GetString(hash_field.value, is_one_byte.value, literal_bytes);
+  }
+  string_table_.insert({string_table_.size() + 1, s});
+  return {s, offset};
+}
+
+inline BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::DeserializeStringTable(uint8_t* serialized_ast, int offset) {
+  auto num_non_constant_entries = DeserializeUint32(serialized_ast, offset);
+  offset = num_non_constant_entries.new_offset;
+
+  for (uint32_t i = 0; i < num_non_constant_entries.value; ++i) {
+    auto string = DeserializeRawString(serialized_ast, offset);
+    offset = string.new_offset;
+  }
+
+  for (base::HashMap::Entry* entry = parser_->ast_value_factory()->string_constants_->string_table()->Start(); entry != nullptr; entry = parser_->ast_value_factory()->string_constants_->string_table()->Next(entry)) {
+    const AstRawString* s = reinterpret_cast<const AstRawString*>(entry->key);
+    string_table_.insert({string_table_.size() + 1, s});
+  }
+
+  return {nullptr, offset};
+}
+
+inline BinAstDeserializer::DeserializeResult<const AstRawString*> BinAstDeserializer::DeserializeRawStringReference(uint8_t* serialized_ast, int offset) {
+  auto string_table_index = DeserializeUint32(serialized_ast, offset);
+  offset = string_table_index.new_offset;
+  if (string_table_index.value == 0) {
+    return {nullptr, offset};
+  }
+  auto lookup_result = string_table_.find(string_table_index.value);
+  DCHECK(lookup_result != string_table_.end());
+  const AstRawString* result = lookup_result->second;
+  DCHECK(result != nullptr);
+  return {result, offset};
+}
+
+inline BinAstDeserializer::DeserializeResult<AstConsString*> BinAstDeserializer::DeserializeConsString(uint8_t* serialized_ast, int offset) {
+  auto raw_string_count = DeserializeUint32(serialized_ast, offset);
+  offset = raw_string_count.new_offset;
+
+  if (raw_string_count.value == 0) {
+    return {nullptr, offset};
+  }
+
+  AstConsString* cons_string = parser_->ast_value_factory()->NewConsString();
+
+  for (uint32_t i = 0; i < raw_string_count.value; ++i) {
+    auto string = DeserializeRawStringReference(serialized_ast, offset);
+    DCHECK(parser_->zone() != nullptr);
+    cons_string->AddString(parser_->zone(), string.value);
+    offset = string.new_offset;
+  }
+
+  return {cons_string, offset};
+}
+
+inline BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::DeserializeLocalVariable(uint8_t* serialized_binast, int offset, Scope* scope) {
+  auto name = DeserializeRawStringReference(serialized_binast, offset);
+  offset = name.new_offset;
+
+  // local_if_not_shadowed_: TODO(binast): how to reference other local variables like this? index?
+  // next_
+
+  auto index = DeserializeInt32(serialized_binast, offset);
+  offset = index.new_offset;
+
+  auto initializer_position = DeserializeInt32(serialized_binast, offset);
+  offset = initializer_position.new_offset;
+
+  auto bit_field = DeserializeUint16(serialized_binast, offset);
+  offset = bit_field.new_offset;
+
+  // We just use bogus values for mode, etc. since they're already encoded in the bit field
+  bool was_added = false;
+  // The main difference between local and non-local is whether the Variable appeared in the locals_ list when the Scope was serialized.
+  Variable* variable = scope->Declare(parser_->zone(), name.value, VariableMode::kVar, NORMAL_VARIABLE, kCreatedInitialized, kMaybeAssigned, &was_added);
+  variable->index_ = index.value;
+  variable->initializer_position_ = initializer_position.value;
+  variable->bit_field_ = bit_field.value;
+  return {variable, offset};
+}
+
+inline BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::DeserializeNonLocalVariable(uint8_t* serialized_binast, int offset, Scope* scope) {
+  auto name = DeserializeRawStringReference(serialized_binast, offset);
+  offset = name.new_offset;
+
+  if (name.value == nullptr) {
+    return {nullptr, offset};
+  }
+
+  // local_if_not_shadowed_: TODO(binast): how to reference other local variables like this? index?
+  // next_
+
+  auto index = DeserializeInt32(serialized_binast, offset);
+  offset = index.new_offset;
+
+  auto initializer_position = DeserializeInt32(serialized_binast, offset);
+  offset = initializer_position.new_offset;
+
+  auto bit_field = DeserializeUint16(serialized_binast, offset);
+  offset = bit_field.new_offset;
+
+  // We just use bogus values for mode, etc. since they're already encoded in the bit field
+  bool was_added = false;
+  // The main difference between local and non-local is whether the Variable appeared in the locals_ list when the Scope was serialized.
+  Variable* variable = scope->variables_.Declare(parser_->zone(), scope, name.value, VariableMode::kVar, NORMAL_VARIABLE, kCreatedInitialized, kMaybeAssigned, IsStaticFlag::kNotStatic, &was_added);
+  variable->index_ = index.value;
+  variable->initializer_position_ = initializer_position.value;
+  variable->bit_field_ = bit_field.value;
+  return {variable, offset};
+}
+
+inline BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::DeserializeVariableReference(uint8_t* serialized_binast, int offset) {
+  auto variable_reference = DeserializeUint32(serialized_binast, offset);
+  offset = variable_reference.new_offset;
+
+  if (variable_reference.value == 0) {
+    return {nullptr, offset};
+  }
+
+  auto variable_result = variables_by_id_.find(variable_reference.value);
+  DCHECK(variable_result != variables_by_id_.end());
+  Variable* variable = variable_result->second;
+
+  return {variable, offset};
+}
+
+inline BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::DeserializeScopeVariable(uint8_t* serialized_binast, int offset, Scope* scope) {
+  auto variable_result = DeserializeNonLocalVariable(serialized_binast, offset, scope);
+  offset = variable_result.new_offset;
+  
+  Variable* variable = variable_result.value;
+  if (variable == nullptr) {
+    return {nullptr, offset};
+  }
+  variables_by_id_.insert({variables_by_id_.size() + 1, variable});
+  return {variable, offset};
+}
+
+// This is for Variables that didn't belong to any particular Scope, i.e. their scope_ field was null.
+inline BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::DeserializeNonScopeVariable(uint8_t* serialized_binast, int offset) {
+  auto name = DeserializeRawStringReference(serialized_binast, offset);
+  offset = name.new_offset;
+
+  if (name.value == nullptr) {
+    return {nullptr, offset};
+  }
+
+  // local_if_not_shadowed_: TODO(binast): how to reference other local variables like this? index?
+  // next_
+
+  auto index = DeserializeInt32(serialized_binast, offset);
+  offset = index.new_offset;
+
+  auto initializer_position = DeserializeInt32(serialized_binast, offset);
+  offset = initializer_position.new_offset;
+
+  auto bit_field = DeserializeUint16(serialized_binast, offset);
+  offset = bit_field.new_offset;
+
+  // We just use bogus values for mode, etc. since they're already encoded in the bit field
+  Variable* variable = new (zone()) Variable(nullptr, name.value, VariableMode::kVar, NORMAL_VARIABLE, kCreatedInitialized, kMaybeAssigned, IsStaticFlag::kNotStatic);
+  variable->index_ = index.value;
+  variable->initializer_position_ = initializer_position.value;
+  variable->bit_field_ = bit_field.value;
+  return {variable, offset};
+}
+
+
+inline BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::DeserializeScopeVariableOrReference(uint8_t* serialized_binast, int offset, Scope* scope) {
+  auto marker_result = DeserializeUint8(serialized_binast, offset);
+  offset = marker_result.new_offset;
+
+  switch (marker_result.value) {
+    case ScopeVariableKind::Null: {
+      return {nullptr, offset};
+    }
+    case ScopeVariableKind::Definition: {
+      auto scope_result = DeserializeScopeVariable(serialized_binast, offset, scope);
+      offset = scope_result.new_offset;
+      return {scope_result.value, offset};
+    }
+    case ScopeVariableKind::Reference: {
+      auto scope_result = DeserializeVariableReference(serialized_binast, offset);
+      offset = scope_result.new_offset;
+      return {scope_result.value, offset};
+    }
+    default: {
+      UNREACHABLE();
+    }
+  }
+}
+
+inline BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::DeserializeNonScopeVariableOrReference(uint8_t* serialized_binast, int offset) {
+  auto marker_result = DeserializeUint8(serialized_binast, offset);
+  offset = marker_result.new_offset;
+
+  switch (marker_result.value) {
+    case ScopeVariableKind::Null: {
+      return {nullptr, offset};
+    }
+    case ScopeVariableKind::Definition: {
+      auto scope_result = DeserializeNonScopeVariable(serialized_binast, offset);
+      offset = scope_result.new_offset;
+      return {scope_result.value, offset};
+    }
+    case ScopeVariableKind::Reference: {
+      auto scope_result = DeserializeVariableReference(serialized_binast, offset);
+      offset = scope_result.new_offset;
+      return {scope_result.value, offset};
+    }
+    default: {
+      UNREACHABLE();
+    }
+  }
+}
+
+inline BinAstDeserializer::DeserializeResult<Literal*> BinAstDeserializer::DeserializeLiteral(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
+  Literal::Type type = Literal::TypeField::decode(bit_field);
+
+  Literal* result;
+  switch (type) {
+    case Literal::kSmi: {
+      auto smi = DeserializeInt32(serialized_binast, offset);
+      offset = smi.new_offset;
+      result = parser_->factory()->NewSmiLiteral(smi.value, position);
+      break;
+    }
+    case Literal::kHeapNumber: {
+      auto number = DeserializeDouble(serialized_binast, offset);
+      offset = number.new_offset;
+      result = parser_->factory()->NewNumberLiteral(number.value, position);
+      break;
+    }
+    case Literal::kBigInt: {
+      auto bigint_str = DeserializeCString(serialized_binast, offset);
+      offset = bigint_str.new_offset;
+      result = parser_->factory()->NewBigIntLiteral(AstBigInt(bigint_str.value), position);
+      break;
+    }
+    case Literal::kString: {
+      auto string = DeserializeRawStringReference(serialized_binast, offset);
+      offset = string.new_offset;
+      result = parser_->factory()->NewStringLiteral(string.value, position);
+      break;
+    }
+    case Literal::kSymbol: {
+      auto symbol = DeserializeUint8(serialized_binast, offset);
+      offset = symbol.new_offset;
+      result = parser_->factory()->NewSymbolLiteral(static_cast<AstSymbol>(symbol.value), position);
+      break;
+    }
+    case Literal::kBoolean: {
+      auto boolean = DeserializeUint8(serialized_binast, position);
+      offset = boolean.new_offset;
+      result = parser_->factory()->NewBooleanLiteral(boolean.value, position);
+      break;
+    }
+    case Literal::kUndefined: {
+      result = parser_->factory()->NewUndefinedLiteral(position);
+      break;
+    }
+    case Literal::kNull: {
+      result = parser_->factory()->NewNullLiteral(position);
+      break;
+    }
+    case Literal::kTheHole: {
+      result = parser_->factory()->NewTheHoleLiteral();
+      break;
+    }
+    default: {
+      UNREACHABLE();
+    }
+  }
+  DCHECK(result->bit_field_ == bit_field);
+
+  return {result, offset};
+}
+
+
+}  // namespace internal
+}  // namespace v8
+
+#endif  // V8_PARSING_BINAST_DESERIALIZER_INL_H_

--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "src/parsing/binast-deserializer.h"
+#include "src/parsing/binast-deserializer-inl.h"
 #include "src/ast/ast.h"
 #include "src/parsing/binast-serialize-visitor.h"
 #include "src/parsing/parser.h"
@@ -18,190 +19,26 @@ BinAstDeserializer::BinAstDeserializer(Parser* parser, Scope* outer_scope)
 {
 }
 
-Zone* BinAstDeserializer::zone() {
-  return parser_->zone();
-}
-
-// TODO(binast): Use templates to de-dupe some of these functions.
-BinAstDeserializer::DeserializeResult<uint64_t> BinAstDeserializer::DeserializeUint64(uint8_t* bytes, int offset) {
-  uint64_t result = 0;
-  for (int i = 0; i < 8; ++i) {
-    size_t shift = sizeof(uint8_t) * 8 * i;
-    uint64_t unshifted_value = bytes[offset + i];
-    uint64_t shifted_value = unshifted_value << shift;
-    result |= shifted_value;
-  }
-  return {result, offset + sizeof(uint64_t)};
-}
-
-BinAstDeserializer::DeserializeResult<uint32_t> BinAstDeserializer::DeserializeUint32(uint8_t* bytes, int offset) {
-  uint32_t result = 0;
-  for (int i = 0; i < 4; ++i) {
-    size_t shift = sizeof(uint8_t) * 8 * i;
-    uint32_t unshifted_value = bytes[offset + i];
-    uint32_t shifted_value = unshifted_value << shift;
-    result |= shifted_value;
-  }
-  return {result, offset + sizeof(uint32_t)};
-}
-
-BinAstDeserializer::DeserializeResult<uint16_t> BinAstDeserializer::DeserializeUint16(uint8_t* bytes, int offset) {
-  uint16_t result = 0;
-  for (int i = 0; i < 2; ++i) {
-    size_t shift = sizeof(uint8_t) * 8 * i;
-    uint32_t unshifted_value = bytes[offset + i];
-    uint32_t shifted_value = unshifted_value << shift;
-    result |= shifted_value;
-  }
-  return {result, offset + sizeof(uint16_t)};
-}
-
-BinAstDeserializer::DeserializeResult<std::array<bool, 16>> BinAstDeserializer::DeserializeUint16Flags(uint8_t* bytes, int offset) {
-  std::array<bool, 16> flags;
-  auto encoded_flags_result = DeserializeUint16(bytes, offset);
-  offset = encoded_flags_result.new_offset;
-  uint16_t encoded_flags = encoded_flags_result.value;
-  for (size_t i = 0; i < flags.size(); ++i) {
-    auto shift = flags.size() - i - 1;
-    flags[i] = (encoded_flags >> shift) & 0x1;
-  }
-  return {flags, offset};
-}
-
-BinAstDeserializer::DeserializeResult<uint8_t> BinAstDeserializer::DeserializeUint8(uint8_t* bytes, int offset) {
-  return {bytes[offset], offset + sizeof(uint8_t)};
-}
-
-BinAstDeserializer::DeserializeResult<int32_t> BinAstDeserializer::DeserializeInt32(uint8_t* bytes, int offset) {
-  uint32_t result = 0;
-  for (int i = 0; i < 4; ++i) {
-    size_t shift = sizeof(uint8_t) * 8 * i;
-    uint32_t unshifted_value = bytes[offset + i];
-    uint32_t shifted_value = unshifted_value << shift;
-    result |= shifted_value;
-  }
-  return {result, offset + sizeof(int32_t)};
-}
-
-BinAstDeserializer::DeserializeResult<double> BinAstDeserializer::DeserializeDouble(uint8_t* bytes, int offset) {
-  union {
-    double d;
-    uint64_t ui;
-  } converter;
-
-  auto result = DeserializeUint64(bytes, offset);
-  offset = result.new_offset;
-  converter.ui = result.value;
-  return {converter.d, offset};
-}
-
-BinAstDeserializer::DeserializeResult<const char*> BinAstDeserializer::DeserializeCString(uint8_t* bytes, int offset) {
-  std::vector<char> characters;
-  for (int i = 0; ; ++i) {
-    auto next_char = DeserializeUint8(bytes, offset);
-    offset = next_char.new_offset;
-    char c = next_char.value;
-    characters.push_back(c);
-    if (c == 0) {
-      break;
-    }
-  }
-  char* result = zone()->NewArray<char>(characters.size());
-  DCHECK(characters.size() > 0);
-  memcpy(result, &characters[0], characters.size());
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<const AstRawString*> BinAstDeserializer::DeserializeRawString(uint8_t* serialized_ast, int offset) {
-  auto is_one_byte = DeserializeUint8(serialized_ast, offset);
-  offset = is_one_byte.new_offset;
-
-  auto hash_field = DeserializeUint32(serialized_ast, offset);
-  offset = hash_field.new_offset;
-
-  auto length = DeserializeUint32(serialized_ast, offset);
-  offset = length.new_offset;
-
-  std::vector<uint8_t> raw_data;
-  for (uint32_t i = 0; i < length.value; ++i) {
-    auto next_byte = DeserializeUint8(serialized_ast, offset);
-    offset = next_byte.new_offset;
-    raw_data.push_back(next_byte.value);
-  }
-  const AstRawString* s = nullptr;
-  if (raw_data.size() > 0) {
-    Vector<const byte> literal_bytes(&raw_data[0], raw_data.size());
-    s = parser_->ast_value_factory()->GetString(hash_field.value, is_one_byte.value, literal_bytes);
-  } else {
-    Vector<const byte> literal_bytes;
-    s = parser_->ast_value_factory()->GetString(hash_field.value, is_one_byte.value, literal_bytes);
-  }
-  string_table_.insert({string_table_.size() + 1, s});
-  return {s, offset};
-}
-
-BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::DeserializeStringTable(uint8_t* serialized_ast, int offset) {
-  auto num_non_constant_entries = DeserializeUint32(serialized_ast, offset);
-  offset = num_non_constant_entries.new_offset;
-
-  for (uint32_t i = 0; i < num_non_constant_entries.value; ++i) {
-    auto string = DeserializeRawString(serialized_ast, offset);
-    offset = string.new_offset;
-  }
-
-  for (base::HashMap::Entry* entry = parser_->ast_value_factory()->string_constants_->string_table()->Start(); entry != nullptr; entry = parser_->ast_value_factory()->string_constants_->string_table()->Next(entry)) {
-    const AstRawString* s = reinterpret_cast<const AstRawString*>(entry->key);
-    string_table_.insert({string_table_.size() + 1, s});
-  }
-
-  return {nullptr, offset};
-}
-
-BinAstDeserializer::DeserializeResult<const AstRawString*> BinAstDeserializer::DeserializeRawStringReference(uint8_t* serialized_ast, int offset) {
-  auto string_table_index = DeserializeUint32(serialized_ast, offset);
-  offset = string_table_index.new_offset;
-  if (string_table_index.value == 0) {
-    return {nullptr, offset};
-  }
-  auto lookup_result = string_table_.find(string_table_index.value);
-  DCHECK(lookup_result != string_table_.end());
-  const AstRawString* result = lookup_result->second;
-  DCHECK(result != nullptr);
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<AstConsString*> BinAstDeserializer::DeserializeConsString(uint8_t* serialized_ast, int offset) {
-  auto raw_string_count = DeserializeUint32(serialized_ast, offset);
-  offset = raw_string_count.new_offset;
-
-  if (raw_string_count.value == 0) {
-    return {nullptr, offset};
-  }
-
-  AstConsString* cons_string = parser_->ast_value_factory()->NewConsString();
-
-  for (uint32_t i = 0; i < raw_string_count.value; ++i) {
-    auto string = DeserializeRawStringReference(serialized_ast, offset);
-    DCHECK(parser_->zone() != nullptr);
-    cons_string->AddString(parser_->zone(), string.value);
-    offset = string.new_offset;
-  }
-
-  return {cons_string, offset};
-}
-
 AstNode* BinAstDeserializer::DeserializeAst(ByteArray serialized_ast) {
+  DCHECK(UseCompression() == BinAstSerializeVisitor::UseCompression());
   std::unique_ptr<uint8_t[]> compressed_byte_array_with_size_header = std::make_unique<uint8_t[]>(serialized_ast.length());
   serialized_ast.copy_out(0, compressed_byte_array_with_size_header.get(), serialized_ast.length());
 
-  size_t original_size = *reinterpret_cast<size_t*>(compressed_byte_array_with_size_header.get());
-  uint8_t* compressed_data = compressed_byte_array_with_size_header.get() + sizeof(size_t);
+  std::unique_ptr<uint8_t[]> uncompressed_byte_array;
+  size_t original_size = 0;
+  if (UseCompression()) {
+    original_size = *reinterpret_cast<size_t*>(compressed_byte_array_with_size_header.get());
+    uint8_t* compressed_data = compressed_byte_array_with_size_header.get() + sizeof(size_t);
 
-  std::unique_ptr<uint8_t[]> uncompressed_byte_array = std::make_unique<uint8_t[]>(original_size);
-  int uncompress_result = uncompress(uncompressed_byte_array.get(), &original_size, compressed_data, serialized_ast.length() - sizeof(size_t));
-  if (uncompress_result != Z_OK) {
-    printf("Error decompressing serialized AST: %s\n", zError(uncompress_result));
-    UNREACHABLE();
+    uncompressed_byte_array = std::make_unique<uint8_t[]>(original_size);
+    int uncompress_result = uncompress(uncompressed_byte_array.get(), &original_size, compressed_data, serialized_ast.length() - sizeof(size_t));
+    if (uncompress_result != Z_OK) {
+      printf("Error decompressing serialized AST: %s\n", zError(uncompress_result));
+      UNREACHABLE();
+    }
+  } else {
+    original_size = serialized_ast.length();
+    uncompressed_byte_array = std::move(compressed_byte_array_with_size_header);
   }
 
   int offset = 0;
@@ -288,167 +125,6 @@ BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::DeserializeA
   default: {
     UNREACHABLE();
   }
-  }
-}
-
-BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::DeserializeLocalVariable(uint8_t* serialized_binast, int offset, Scope* scope) {
-  auto name = DeserializeRawStringReference(serialized_binast, offset);
-  offset = name.new_offset;
-
-  // local_if_not_shadowed_: TODO(binast): how to reference other local variables like this? index?
-  // next_
-
-  auto index = DeserializeInt32(serialized_binast, offset);
-  offset = index.new_offset;
-
-  auto initializer_position = DeserializeInt32(serialized_binast, offset);
-  offset = initializer_position.new_offset;
-
-  auto bit_field = DeserializeUint16(serialized_binast, offset);
-  offset = bit_field.new_offset;
-
-  // We just use bogus values for mode, etc. since they're already encoded in the bit field
-  bool was_added = false;
-  // The main difference between local and non-local is whether the Variable appeared in the locals_ list when the Scope was serialized.
-  Variable* variable = scope->Declare(parser_->zone(), name.value, VariableMode::kVar, NORMAL_VARIABLE, kCreatedInitialized, kMaybeAssigned, &was_added);
-  variable->index_ = index.value;
-  variable->initializer_position_ = initializer_position.value;
-  variable->bit_field_ = bit_field.value;
-  return {variable, offset};
-}
-
-BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::DeserializeNonLocalVariable(uint8_t* serialized_binast, int offset, Scope* scope) {
-  auto name = DeserializeRawStringReference(serialized_binast, offset);
-  offset = name.new_offset;
-
-  if (name.value == nullptr) {
-    return {nullptr, offset};
-  }
-
-  // local_if_not_shadowed_: TODO(binast): how to reference other local variables like this? index?
-  // next_
-
-  auto index = DeserializeInt32(serialized_binast, offset);
-  offset = index.new_offset;
-
-  auto initializer_position = DeserializeInt32(serialized_binast, offset);
-  offset = initializer_position.new_offset;
-
-  auto bit_field = DeserializeUint16(serialized_binast, offset);
-  offset = bit_field.new_offset;
-
-  // We just use bogus values for mode, etc. since they're already encoded in the bit field
-  bool was_added = false;
-  // The main difference between local and non-local is whether the Variable appeared in the locals_ list when the Scope was serialized.
-  Variable* variable = scope->variables_.Declare(parser_->zone(), scope, name.value, VariableMode::kVar, NORMAL_VARIABLE, kCreatedInitialized, kMaybeAssigned, IsStaticFlag::kNotStatic, &was_added);
-  variable->index_ = index.value;
-  variable->initializer_position_ = initializer_position.value;
-  variable->bit_field_ = bit_field.value;
-  return {variable, offset};
-}
-
-BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::DeserializeVariableReference(uint8_t* serialized_binast, int offset) {
-  auto variable_reference = DeserializeUint32(serialized_binast, offset);
-  offset = variable_reference.new_offset;
-
-  if (variable_reference.value == 0) {
-    return {nullptr, offset};
-  }
-
-  auto variable_result = variables_by_id_.find(variable_reference.value);
-  DCHECK(variable_result != variables_by_id_.end());
-  Variable* variable = variable_result->second;
-
-  return {variable, offset};
-}
-
-BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::DeserializeScopeVariable(uint8_t* serialized_binast, int offset, Scope* scope) {
-  auto variable_result = DeserializeNonLocalVariable(serialized_binast, offset, scope);
-  offset = variable_result.new_offset;
-  
-  Variable* variable = variable_result.value;
-  if (variable == nullptr) {
-    return {nullptr, offset};
-  }
-  variables_by_id_.insert({variables_by_id_.size() + 1, variable});
-  return {variable, offset};
-}
-
-// This is for Variables that didn't belong to any particular Scope, i.e. their scope_ field was null.
-BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::DeserializeNonScopeVariable(uint8_t* serialized_binast, int offset) {
-  auto name = DeserializeRawStringReference(serialized_binast, offset);
-  offset = name.new_offset;
-
-  if (name.value == nullptr) {
-    return {nullptr, offset};
-  }
-
-  // local_if_not_shadowed_: TODO(binast): how to reference other local variables like this? index?
-  // next_
-
-  auto index = DeserializeInt32(serialized_binast, offset);
-  offset = index.new_offset;
-
-  auto initializer_position = DeserializeInt32(serialized_binast, offset);
-  offset = initializer_position.new_offset;
-
-  auto bit_field = DeserializeUint16(serialized_binast, offset);
-  offset = bit_field.new_offset;
-
-  // We just use bogus values for mode, etc. since they're already encoded in the bit field
-  Variable* variable = new (zone()) Variable(nullptr, name.value, VariableMode::kVar, NORMAL_VARIABLE, kCreatedInitialized, kMaybeAssigned, IsStaticFlag::kNotStatic);
-  variable->index_ = index.value;
-  variable->initializer_position_ = initializer_position.value;
-  variable->bit_field_ = bit_field.value;
-  return {variable, offset};
-}
-
-
-BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::DeserializeScopeVariableOrReference(uint8_t* serialized_binast, int offset, Scope* scope) {
-  auto marker_result = DeserializeUint8(serialized_binast, offset);
-  offset = marker_result.new_offset;
-
-  switch (marker_result.value) {
-    case ScopeVariableKind::Null: {
-      return {nullptr, offset};
-    }
-    case ScopeVariableKind::Definition: {
-      auto scope_result = DeserializeScopeVariable(serialized_binast, offset, scope);
-      offset = scope_result.new_offset;
-      return {scope_result.value, offset};
-    }
-    case ScopeVariableKind::Reference: {
-      auto scope_result = DeserializeVariableReference(serialized_binast, offset);
-      offset = scope_result.new_offset;
-      return {scope_result.value, offset};
-    }
-    default: {
-      UNREACHABLE();
-    }
-  }
-}
-
-BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::DeserializeNonScopeVariableOrReference(uint8_t* serialized_binast, int offset) {
-  auto marker_result = DeserializeUint8(serialized_binast, offset);
-  offset = marker_result.new_offset;
-
-  switch (marker_result.value) {
-    case ScopeVariableKind::Null: {
-      return {nullptr, offset};
-    }
-    case ScopeVariableKind::Definition: {
-      auto scope_result = DeserializeNonScopeVariable(serialized_binast, offset);
-      offset = scope_result.new_offset;
-      return {scope_result.value, offset};
-    }
-    case ScopeVariableKind::Reference: {
-      auto scope_result = DeserializeVariableReference(serialized_binast, offset);
-      offset = scope_result.new_offset;
-      return {scope_result.value, offset};
-    }
-    default: {
-      UNREACHABLE();
-    }
   }
 }
 
@@ -842,68 +518,6 @@ BinAstDeserializer::DeserializeResult<VariableProxyExpression*> BinAstDeserializ
 
   VariableProxyExpression* result = parser_->factory()->NewVariableProxyExpression(variable_proxy.value);
   result->bit_field_ = bit_field;
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<Literal*> BinAstDeserializer::DeserializeLiteral(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  Literal::Type type = Literal::TypeField::decode(bit_field);
-
-  Literal* result;
-  switch (type) {
-    case Literal::kSmi: {
-      auto smi = DeserializeInt32(serialized_binast, offset);
-      offset = smi.new_offset;
-      result = parser_->factory()->NewSmiLiteral(smi.value, position);
-      break;
-    }
-    case Literal::kHeapNumber: {
-      auto number = DeserializeDouble(serialized_binast, offset);
-      offset = number.new_offset;
-      result = parser_->factory()->NewNumberLiteral(number.value, position);
-      break;
-    }
-    case Literal::kBigInt: {
-      auto bigint_str = DeserializeCString(serialized_binast, offset);
-      offset = bigint_str.new_offset;
-      result = parser_->factory()->NewBigIntLiteral(AstBigInt(bigint_str.value), position);
-      break;
-    }
-    case Literal::kString: {
-      auto string = DeserializeRawStringReference(serialized_binast, offset);
-      offset = string.new_offset;
-      result = parser_->factory()->NewStringLiteral(string.value, position);
-      break;
-    }
-    case Literal::kSymbol: {
-      auto symbol = DeserializeUint8(serialized_binast, offset);
-      offset = symbol.new_offset;
-      result = parser_->factory()->NewSymbolLiteral(static_cast<AstSymbol>(symbol.value), position);
-      break;
-    }
-    case Literal::kBoolean: {
-      auto boolean = DeserializeUint8(serialized_binast, position);
-      offset = boolean.new_offset;
-      result = parser_->factory()->NewBooleanLiteral(boolean.value, position);
-      break;
-    }
-    case Literal::kUndefined: {
-      result = parser_->factory()->NewUndefinedLiteral(position);
-      break;
-    }
-    case Literal::kNull: {
-      result = parser_->factory()->NewNullLiteral(position);
-      break;
-    }
-    case Literal::kTheHole: {
-      result = parser_->factory()->NewTheHoleLiteral();
-      break;
-    }
-    default: {
-      UNREACHABLE();
-    }
-  }
-  DCHECK(result->bit_field_ == bit_field);
-
   return {result, offset};
 }
 

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -33,6 +33,7 @@ class BinAstDeserializer {
   };
 
   Zone* zone();
+  static bool UseCompression() { return false; }
 
   DeserializeResult<uint64_t> DeserializeUint64(uint8_t* bytes, int offset);
   DeserializeResult<uint32_t> DeserializeUint32(uint8_t* bytes, int offset);

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -18,7 +18,6 @@ enum ScopeVariableKind : uint8_t {
   Definition = 2,
 };
 
-// TODO(binast)
 // Serializes binAST format into a linear sequence of bytes.
 class BinAstSerializeVisitor final : public BinAstVisitor {
  public:
@@ -28,8 +27,20 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
       encountered_unhandled_node_(false) {
   }
 
-  uint8_t* serialized_bytes() const { return compressed_byte_data_.get(); }
-  size_t serialized_bytes_length() const { return compressed_byte_data_length_; }
+  uint8_t* serialized_bytes() const {
+    if (UseCompression()) {
+      return compressed_byte_data_.get();
+    } else {
+      return const_cast<uint8_t*>(&byte_data_[0]);
+    }
+  }
+  size_t serialized_bytes_length() const {
+    if (UseCompression()) {
+      return compressed_byte_data_length_;
+    } else {
+      return byte_data_.size();
+    }
+  }
 
   bool SerializeAst(AstNode* root);
 
@@ -53,6 +64,9 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   virtual void VisitArrayLiteral(ArrayLiteral *array_literal) override;
 
  private:
+  friend class BinAstDeserializer;
+  static bool UseCompression() { return false; }
+
   void SerializeUint8(uint8_t value);
   void SerializeUint16(uint16_t value);
   void SerializeUint16Flags(const std::list<bool>& flags);
@@ -83,11 +97,12 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   AstValueFactory* ast_value_factory_;
   std::unordered_map<const AstRawString*, uint32_t> string_table_indices_;
   std::vector<uint8_t> byte_data_;
-  std::unique_ptr<uint8_t[]> compressed_byte_data_;
-  size_t compressed_byte_data_length_;
   std::unordered_map<Variable*, uint32_t> variable_ids_;
   std::unordered_map<VariableProxy*, int> var_proxy_ids;
   bool encountered_unhandled_node_;
+
+  std::unique_ptr<uint8_t[]> compressed_byte_data_;
+  size_t compressed_byte_data_length_;
 };
 
 // TODO(binast): Maybe templatize these to reduce duplication?
@@ -217,6 +232,7 @@ inline void BinAstSerializeVisitor::SerializeConsString(const AstConsString* con
   for (const AstRawString* string : strings) {
     DCHECK(string != nullptr);
     DCHECK(string_table_indices_.count(string) == 1);
+    (void)string;
     length += 1;
   }
 
@@ -277,8 +293,6 @@ inline void BinAstSerializeVisitor::SerializeStringTable(const AstConsString* fu
 }
 
 inline bool BinAstSerializeVisitor::SerializeAst(AstNode* root) {
-  static std::mutex class_lock ;
-  std::lock_guard<std::mutex> lock( class_lock ) ;
   auto start = std::chrono::high_resolution_clock::now();
   FunctionLiteral* literal = root->AsFunctionLiteral();
   DCHECK(literal != nullptr);
@@ -289,15 +303,17 @@ inline bool BinAstSerializeVisitor::SerializeAst(AstNode* root) {
     return false;
   }
 
-  compressed_byte_data_ = std::make_unique<byte[]>(byte_data_.size() + sizeof(size_t));
-  size_t compressed_data_size = byte_data_.size();
-  int compress_result = compress2(compressed_byte_data_.get() + sizeof(size_t), &compressed_data_size, &byte_data_[0], byte_data_.size(), /* level */9);
-  if (compress_result == Z_OK) {
-    compressed_byte_data_length_ = compressed_data_size + sizeof(size_t);
-    *reinterpret_cast<size_t*>(compressed_byte_data_.get()) = byte_data_.size();
-  } else {
-    printf("\nError compressing serialized AST: %s\n", zError(compress_result));
-    return false;
+  if (UseCompression()) {
+    compressed_byte_data_ = std::make_unique<byte[]>(byte_data_.size() + sizeof(size_t));
+    size_t compressed_data_size = byte_data_.size();
+    int compress_result = compress2(compressed_byte_data_.get() + sizeof(size_t), &compressed_data_size, &byte_data_[0], byte_data_.size(), /* level */6);
+    if (compress_result == Z_OK) {
+      compressed_byte_data_length_ = compressed_data_size + sizeof(size_t);
+      *reinterpret_cast<size_t*>(compressed_byte_data_.get()) = byte_data_.size();
+    } else {
+      printf("\nError compressing serialized AST: %s\n", zError(compress_result));
+      return false;
+    }
   }
 
   auto elapsed = std::chrono::high_resolution_clock::now() - start;

--- a/test/binast/test.js
+++ b/test/binast/test.js
@@ -3,23 +3,23 @@
 var double = function(x) { return x * 2; }
 function triple(x) { return x * 3; }
 function deep() {
-  return function() {
-    return function() {
-    return function() {
-    return function() {
-    return function() {
-    return function() {
-    return function() {
-    return function() {
-    return function() {
-    return function() {
-    return function() {
-    return function() {
-    return function() {
-    return function() {
-    return function() {
-    return function() {
-    return function() {
+  return function level0() {
+    return function level1() {
+    return function level2() {
+    return function level3() {
+    return function level4() {
+    return function level5() {
+    return function level6() {
+    return function level7() {
+    return function level8() {
+    return function level9() {
+    return function level10() {
+    return function level11() {
+    return function level12() {
+    return function level13() {
+    return function level14() {
+    return function level15() {
+    return function level16() {
       return 42;
     };
     };
@@ -57,7 +57,7 @@ function newSetTimeout(func, delayMs) {
   newCallback.deadline = deadline;
   timerCallbacks.push(newCallback);
   // Reverse sort so back of the array has the nearest timer callbacks
-  timerCallbacks.sort(function(e1, e2) {
+  timerCallbacks.sort(function sortFunction(e1, e2) {
     return e2.deadline - e1.deadline;
   });
 };


### PR DESCRIPTION
After some simple performance experiments we realized that compression was
a pretty big performance regression. There are still some experiments we want
to perform, but for now this diff makes it easy to enable/disable and disables
it by default. Also some other performance related changes (the new inlines
file for the deserializer) as well as miscellaneous cleanup.