### PR TITLE
Add de/serializer support for ForStatement AstNodes

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -2085,6 +2085,7 @@ class CountOperation final : public Expression {
 
  private:
   friend class AstNodeFactory;
+  friend class BinAstDeserializer;
 
   CountOperation(Token::Value op, bool is_prefix, Expression* expr, int pos)
       : Expression(pos, kCountOperation), expression_(expr) {

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -80,6 +80,9 @@ class BinAstDeserializer {
   DeserializeResult<Assignment*> DeserializeAssignment(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<CompareOperation*> DeserializeCompareOperation(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<EmptyStatement*> DeserializeEmptyStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
+  DeserializeResult<ForStatement*> DeserializeForStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
+  DeserializeResult<CountOperation*> DeserializeCountOperation(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
+  DeserializeResult<CompoundAssignment*> DeserializeCompoundAssignment(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<std::nullptr_t> DeserializeNodeStub(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
 
   Parser* parser_;

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -62,6 +62,7 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   virtual void VisitBinaryOperation(BinaryOperation* binary_op) override;
   virtual void VisitObjectLiteral(ObjectLiteral* binary_op) override;
   virtual void VisitArrayLiteral(ArrayLiteral *array_literal) override;
+  virtual void VisitCompoundAssignment(CompoundAssignment* compound_assignment) override;
 
  private:
   friend class BinAstDeserializer;
@@ -516,8 +517,8 @@ inline void BinAstSerializeVisitor::SerializeVariableProxy(VariableProxy* proxy)
 
 inline void BinAstSerializeVisitor::ToDoBinAst(AstNode* node) {
   // TODO(binast): Delete this function when it's no longer needed.
-  // UNREACHABLE();
   printf("BinAstSerializeVisitor encountered unhandled node type: %s\n", node->node_type_name());
+  // UNREACHABLE();
   encountered_unhandled_node_ = true;
 }
 
@@ -622,7 +623,10 @@ inline void BinAstSerializeVisitor::VisitVariableProxyExpression(VariableProxyEx
 
 inline void BinAstSerializeVisitor::VisitForStatement(ForStatement* for_statement) {
   SerializeAstNodeHeader(for_statement);
-  ToDoBinAst(for_statement);
+  VisitNode(for_statement->init());
+  VisitNode(for_statement->cond());
+  VisitNode(for_statement->next());
+  VisitNode(for_statement->body());
 }
 
 inline void BinAstSerializeVisitor::VisitCompareOperation(CompareOperation* compare) {
@@ -633,7 +637,7 @@ inline void BinAstSerializeVisitor::VisitCompareOperation(CompareOperation* comp
 
 inline void BinAstSerializeVisitor::VisitCountOperation(CountOperation* operation) {
   SerializeAstNodeHeader(operation);
-  ToDoBinAst(operation);
+  VisitNode(operation->expression());
 }
 
 inline void BinAstSerializeVisitor::VisitCall(Call* call) {
@@ -680,6 +684,13 @@ inline void BinAstSerializeVisitor::VisitObjectLiteral(ObjectLiteral* object_lit
 inline void BinAstSerializeVisitor::VisitArrayLiteral(ArrayLiteral* array_literal) {
   SerializeAstNodeHeader(array_literal);
   ToDoBinAst(array_literal);
+}
+
+inline void BinAstSerializeVisitor::VisitCompoundAssignment(CompoundAssignment* compound_assignment) {
+  SerializeAstNodeHeader(compound_assignment);
+  VisitNode(compound_assignment->target());
+  VisitNode(compound_assignment->value());
+  VisitNode(compound_assignment->binary_operation());
 }
 
 }  // namespace internal

--- a/src/parsing/binast-visitor.h
+++ b/src/parsing/binast-visitor.h
@@ -30,7 +30,7 @@ public:
   virtual void VisitBinaryOperation(BinaryOperation* binary_op) = 0;
   virtual void VisitObjectLiteral(ObjectLiteral* object_literal) = 0;
   virtual void VisitArrayLiteral(ArrayLiteral* array_literal) = 0;
-
+  virtual void VisitCompoundAssignment(CompoundAssignment* compound_assignment) = 0;
 
   void VisitNode(AstNode* node) {
     switch (node->node_type()) {
@@ -121,6 +121,11 @@ public:
 
       case AstNode::kArrayLiteral: {
         VisitArrayLiteral(static_cast<ArrayLiteral*>(node));
+        break;
+      }
+
+      case AstNode::kCompoundAssignment: {
+        VisitCompoundAssignment(static_cast<CompoundAssignment*>(node));
         break;
       }
 


### PR DESCRIPTION
This diff adds the implementations for ForStatement, CountOperation, and CompoundAssignment
that basic for loops require to work.