### PR TITLE
Add de/serializer support for ForInStatement nodes

### DIFF
--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -119,6 +119,10 @@ BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::DeserializeA
     auto result = DeserializeForStatement(serialized_binast, bit_field.value, position.value, offset);
     return {result.value, result.new_offset};
   }
+  case AstNode::kForInStatement: {
+    auto result = DeserializeForInStatement(serialized_binast, bit_field.value, position.value, offset);
+    return {result.value, result.new_offset};
+  }
   case AstNode::kCountOperation: {
     auto result = DeserializeCountOperation(serialized_binast, bit_field.value, position.value, offset);
     return {result.value, result.new_offset};
@@ -681,6 +685,23 @@ BinAstDeserializer::DeserializeResult<ForStatement*> BinAstDeserializer::Deseria
   result->Initialize(static_cast<Statement*>(init.value), static_cast<Expression*>(cond.value), static_cast<Statement*>(next.value), static_cast<Statement*>(body.value));
   DCHECK(result->bit_field_ == bit_field);
   return {result, offset};
+}
+
+BinAstDeserializer::DeserializeResult<ForInStatement*> BinAstDeserializer::DeserializeForInStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
+  auto each = DeserializeAstNode(serialized_binast, offset);
+  offset = each.new_offset;
+
+  auto subject = DeserializeAstNode(serialized_binast, offset);
+  offset = subject.new_offset;
+
+  auto body = DeserializeAstNode(serialized_binast, offset);
+  offset = body.new_offset;
+
+  ForEachStatement* result = parser_->factory()->NewForEachStatement(ForEachStatement::ENUMERATE, position);
+  result->Initialize(static_cast<Expression*>(each.value), static_cast<Expression*>(subject.value), static_cast<Statement*>(body.value));
+  DCHECK(result->bit_field_ == bit_field);
+  DCHECK(result->IsForInStatement());
+  return {static_cast<ForInStatement*>(result), offset};
 }
 
 BinAstDeserializer::DeserializeResult<WhileStatement*> BinAstDeserializer::DeserializeWhileStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -81,6 +81,7 @@ class BinAstDeserializer {
   DeserializeResult<CompareOperation*> DeserializeCompareOperation(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<EmptyStatement*> DeserializeEmptyStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<ForStatement*> DeserializeForStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
+  DeserializeResult<ForInStatement*> DeserializeForInStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<WhileStatement*> DeserializeWhileStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<DoWhileStatement*> DeserializeDoWhileStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<CountOperation*> DeserializeCountOperation(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);

--- a/src/parsing/binast-visitor.h
+++ b/src/parsing/binast-visitor.h
@@ -21,6 +21,7 @@ public:
   virtual void VisitAssignment(Assignment* assignment) = 0;
   virtual void VisitVariableProxyExpression(VariableProxyExpression* var_proxy) = 0;
   virtual void VisitForStatement(ForStatement* for_statement) = 0;
+  virtual void VisitForInStatement(ForInStatement* for_in_statement) = 0;
   virtual void VisitWhileStatement(WhileStatement* while_statement) = 0;
   virtual void VisitDoWhileStatement(DoWhileStatement* do_while_statement) = 0;
   virtual void VisitCompareOperation(CompareOperation* compare) = 0;
@@ -78,6 +79,11 @@ public:
 
       case AstNode::kForStatement: {
         VisitForStatement(static_cast<ForStatement*>(node));
+        break;
+      }
+
+      case AstNode::kForInStatement: {
+        VisitForInStatement(static_cast<ForInStatement*>(node));
         break;
       }
 

--- a/test/binast/test.js
+++ b/test/binast/test.js
@@ -39,10 +39,17 @@ function deep() {
     };
   };
 }
-function sum(n) {
+function sumFor(n) {
   var result = 0;
   for (var i = 0; i < n; ++i) {
     result += i;
+  }
+  return result;
+}
+function sumForIn(arr) {
+  var result = 0;
+  for (var i in arr) {
+    result += arr[i];
   }
   return result;
 }
@@ -114,7 +121,8 @@ setTimeout(function testCallback2() {
   console.log(double(42));
   console.log(triple(24));
   console.log(deep()()()()()()()()()()()()()()()()()());
-  console.log(sum(10));
+  console.log(sumFor(10));
+  console.log(sumForIn([1,2,3,4,5,6,7,8,9,10]));
   console.log(sumWhile(10));
   console.log(sumDoWhile(10));
 }, 5000);


### PR DESCRIPTION
This completes our binAST support for ES5 loops. Relatively straightforward,
but required fixing a bug related to how we were serializing Variables.
Namely it was possible for there to be Variables contained in the Scope's
locals_ that weren't in the main variables_ map (due to some desugaring logic
that created Temporary Variables), but the code implicitly assumed otherwise.