### PR TITLE
Add varint encoding for string and variable indices

### DIFF
--- a/src/parsing/binast-deserializer-inl.h
+++ b/src/parsing/binast-deserializer-inl.h
@@ -39,6 +39,25 @@ inline BinAstDeserializer::DeserializeResult<uint32_t> BinAstDeserializer::Deser
   return {result, offset + sizeof(uint32_t)};
 }
 
+inline BinAstDeserializer::DeserializeResult<uint32_t> BinAstDeserializer::DeserializeVarUint32(uint8_t* bytes, int offset) {
+  int i = 0;
+  uint32_t result = 0;
+  while (true) {
+    DCHECK(i < 4);
+    uint32_t current_byte = bytes[offset + i];
+    uint32_t raw_byte_value = current_byte & 0x7f;
+    uint32_t shifted_byte_value = raw_byte_value << (7 * i);
+    result |= shifted_byte_value;
+
+    bool has_next_byte = current_byte & 0x80;
+    if (!has_next_byte) {
+      break;
+    }
+    i += 1;
+  }
+  return {result, offset + i + 1};
+}
+
 inline BinAstDeserializer::DeserializeResult<uint16_t> BinAstDeserializer::DeserializeUint16(uint8_t* bytes, int offset) {
   uint16_t result = 0;
   for (int i = 0; i < 2; ++i) {
@@ -152,7 +171,7 @@ inline BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer:
 }
 
 inline BinAstDeserializer::DeserializeResult<const AstRawString*> BinAstDeserializer::DeserializeRawStringReference(uint8_t* serialized_ast, int offset) {
-  auto string_table_index = DeserializeUint32(serialized_ast, offset);
+  auto string_table_index = DeserializeVarUint32(serialized_ast, offset);
   offset = string_table_index.new_offset;
   if (string_table_index.value == 0) {
     return {nullptr, offset};
@@ -241,7 +260,7 @@ inline BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::Dese
 }
 
 inline BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::DeserializeVariableReference(uint8_t* serialized_binast, int offset) {
-  auto variable_reference = DeserializeUint32(serialized_binast, offset);
+  auto variable_reference = DeserializeVarUint32(serialized_binast, offset);
   offset = variable_reference.new_offset;
 
   if (variable_reference.value == 0) {

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -37,6 +37,8 @@ class BinAstDeserializer {
 
   DeserializeResult<uint64_t> DeserializeUint64(uint8_t* bytes, int offset);
   DeserializeResult<uint32_t> DeserializeUint32(uint8_t* bytes, int offset);
+  DeserializeResult<uint32_t> DeserializeVarUint32(uint8_t* bytes, int offset);
+
   DeserializeResult<uint16_t> DeserializeUint16(uint8_t* bytes, int offset);
   DeserializeResult<uint8_t> DeserializeUint8(uint8_t* bytes, int offset);
   DeserializeResult<int32_t> DeserializeInt32(uint8_t* bytes, int offset);


### PR DESCRIPTION
The encoding for these uint32 indices is done in 7 bit chunks with an
the extra top bit indicating whether there is another byte that follows.
On our test script this reduced the size of our uncompressed serialized
AST by varying amounts, from ~10% up to 33%. If I had to guess, a typical
function would probably be closer to 10% savings.