### PR TITLE
De/serialization for inner functions

### DIFF
--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -60,6 +60,12 @@ BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::DeserializeA
   AstNode::NodeType nodeType = AstNode::NodeTypeField::decode(bit_field.value);
   switch (nodeType) {
   case AstNode::kFunctionLiteral: {
+    auto start_offset = DeserializeUint32(serialized_binast, offset);
+    offset = start_offset.new_offset;
+
+    auto length = DeserializeUint32(serialized_binast, offset);
+    offset = length.new_offset;
+
     auto result = DeserializeFunctionLiteral(serialized_binast, bit_field.value, position.value, offset);
     return {result.value, result.new_offset};
   }

--- a/src/parsing/binast-parser.cc
+++ b/src/parsing/binast-parser.cc
@@ -307,26 +307,12 @@ FunctionLiteral* BinAstParser::ParseFunctionLiteral(
   }
   scope->set_start_position(position());
 
-  // Eager or lazy parse? If is_lazy_top_level_function, we'll parse
-  // lazily. We'll call SkipFunction, which may decide to
-  // abort lazy parsing if it suspects that wasn't a good idea. If so (in
-  // which case the parser is expected to have backtracked), or if we didn't
-  // try to lazy parse in the first place, we'll have to parse eagerly.
-  bool did_preparse_successfully =
-      should_preparse &&
-      SkipFunction(function_name, kind, function_syntax_kind, scope,
-                   &num_parameters, &function_length, &produced_preparse_data);
-
-  if (!did_preparse_successfully) {
-    // If skipping aborted, it rewound the scanner until before the LPAREN.
-    // Consume it in that case.
-    if (should_preparse) Consume(Token::LPAREN);
-    should_post_parallel_task = false;
-    ParseFunction(&body, function_name, pos, kind, function_syntax_kind, scope,
-                  &num_parameters, &function_length, &has_duplicate_parameters,
-                  &expected_property_count, &suspend_count,
-                  arguments_for_wrapped_function);
-  }
+  if (should_preparse) Consume(Token::LPAREN);
+  should_post_parallel_task = false;
+  ParseFunction(&body, function_name, pos, kind, function_syntax_kind, scope,
+                &num_parameters, &function_length, &has_duplicate_parameters,
+                &expected_property_count, &suspend_count,
+                arguments_for_wrapped_function);
 
   if (V8_UNLIKELY(FLAG_log_function_events)) {
     double ms = timer.Elapsed().InMillisecondsF();
@@ -339,14 +325,6 @@ FunctionLiteral* BinAstParser::ParseFunctionLiteral(
         scope->end_position(),
         reinterpret_cast<const char*>(function_name->raw_data()),
         function_name->byte_length());
-  }
-  if (V8_UNLIKELY(TracingFlags::is_runtime_stats_enabled()) &&
-      did_preparse_successfully) {
-    if (runtime_call_stats_) {
-      runtime_call_stats_->CorrectCurrentCounterId(
-          RuntimeCallCounterId::kPreParseWithVariableResolution,
-          RuntimeCallStats::kThreadSpecific);
-    }
   }
 
   // Validate function name. We can do this only after parsing the function,


### PR DESCRIPTION
- `BinAstInnerFunctionLiteralOffset` stucts are created during serialization for each inner function literal and pushed onto a vector
- offsets are moved into a `PodArray` on `BinAstParseData`, which is set on SFI
- upon deserialization, pass offsets array in to `BinAstDeserializer` alongside serialized AST
  - offsets get saved as a member of `BinAstDeserializer` 
  - `BinAstDeserializer` becomes a member of `AbstractParser` so it can stay alive
  - this is not actually utilized currently, but i had imagined that the parser would move on to inner functions and, if available in the serialized data, would pull that out of `BinAstDeserializer` instead of parsing?
  - since `BinAstDeserializer` is currently not skipping inner functions, i also had temporarily added a map of `<function_literal_id, FunctionLiteral*>` to avoid re-deserialization, but ultimately we'd want to skip inner function deserialization initially and use the saved offset to deserialize as needed
- ultimately, the inner functions are still getting re-parsed. do i need to get the serialized data onto their SFIs somehow? any ideas how to do that? or, is there something i can do with the inner `FunctionLiteral`s after the parent function deserializes that would prevent them from reparsing?

also, am i overusing `std::move`? extremely did not feel like i knew what i was doing when passing around the offsets vector