### PR TITLE
Fix graceful failures on unimplemented nodes

### DIFF
--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -62,10 +62,20 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   virtual void VisitCallNew(CallNew* call) override;
   virtual void VisitProperty(Property* property) override;
   virtual void VisitReturnStatement(ReturnStatement* return_statement) override;
+  virtual void VisitUnaryOperation(UnaryOperation* unary_op) override;
   virtual void VisitBinaryOperation(BinaryOperation* binary_op) override;
+  virtual void VisitNaryOperation(NaryOperation* nary_op) override;
+
   virtual void VisitObjectLiteral(ObjectLiteral* binary_op) override;
-  virtual void VisitArrayLiteral(ArrayLiteral *array_literal) override;
-  virtual void VisitCompoundAssignment(CompoundAssignment* compound_assignment) override;
+  virtual void VisitArrayLiteral(ArrayLiteral* array_literal) override;
+  virtual void VisitCompoundAssignment(
+      CompoundAssignment* compound_assignment) override;
+  virtual void VisitConditional(Conditional* conditional) override;
+  virtual void VisitTryCatchStatement(
+      TryCatchStatement* try_catch_statement) override;
+  virtual void VisitThrow(Throw* throw_statement) override;
+  virtual void VisitThisExpression(ThisExpression* this_expression) override;
+  virtual void VisitRegExpLiteral(RegExpLiteral* reg_exp_literal) override;
 
  private:
   friend class BinAstDeserializer;
@@ -699,10 +709,20 @@ inline void BinAstSerializeVisitor::VisitReturnStatement(ReturnStatement* return
   VisitNode(return_statement->expression());
 }
 
+inline void BinAstSerializeVisitor::VisitUnaryOperation(UnaryOperation* unary_op) {
+  SerializeAstNodeHeader(unary_op);
+  ToDoBinAst(unary_op);
+}
+
 inline void BinAstSerializeVisitor::VisitBinaryOperation(BinaryOperation* binary_op) {
   SerializeAstNodeHeader(binary_op);
   VisitNode(binary_op->left());
   VisitNode(binary_op->right());
+}
+
+inline void BinAstSerializeVisitor::VisitNaryOperation(NaryOperation* nary_op) {
+  SerializeAstNodeHeader(nary_op);
+  ToDoBinAst(nary_op);
 }
 
 inline void BinAstSerializeVisitor::VisitObjectLiteral(ObjectLiteral* object_literal) {
@@ -720,6 +740,34 @@ inline void BinAstSerializeVisitor::VisitCompoundAssignment(CompoundAssignment* 
   VisitNode(compound_assignment->target());
   VisitNode(compound_assignment->value());
   VisitNode(compound_assignment->binary_operation());
+}
+
+inline void BinAstSerializeVisitor::VisitConditional(Conditional* conditional) {
+  SerializeAstNodeHeader(conditional);
+  ToDoBinAst(conditional);
+}
+
+inline void BinAstSerializeVisitor::VisitTryCatchStatement(
+    TryCatchStatement* try_catch_statement) {
+  SerializeAstNodeHeader(try_catch_statement);
+  ToDoBinAst(try_catch_statement);
+}
+
+inline void BinAstSerializeVisitor::VisitThrow(Throw* throw_statement) {
+  SerializeAstNodeHeader(throw_statement);
+  ToDoBinAst(throw_statement);
+}
+
+inline void BinAstSerializeVisitor::VisitThisExpression(
+    ThisExpression* this_expression) {
+  SerializeAstNodeHeader(this_expression);
+  ToDoBinAst(this_expression);
+}
+
+inline void BinAstSerializeVisitor::VisitRegExpLiteral(
+    RegExpLiteral* reg_exp_literal) {
+  SerializeAstNodeHeader(reg_exp_literal);
+  ToDoBinAst(reg_exp_literal);
 }
 
 }  // namespace internal

--- a/src/parsing/binast-visitor.h
+++ b/src/parsing/binast-visitor.h
@@ -30,10 +30,17 @@ public:
   virtual void VisitCallNew(CallNew* call) = 0;
   virtual void VisitProperty(Property* property) = 0;
   virtual void VisitReturnStatement(ReturnStatement* return_statement) = 0;
+  virtual void VisitUnaryOperation(UnaryOperation* unary_op) = 0;
   virtual void VisitBinaryOperation(BinaryOperation* binary_op) = 0;
+  virtual void VisitNaryOperation(NaryOperation* nary_op) = 0;
   virtual void VisitObjectLiteral(ObjectLiteral* object_literal) = 0;
   virtual void VisitArrayLiteral(ArrayLiteral* array_literal) = 0;
   virtual void VisitCompoundAssignment(CompoundAssignment* compound_assignment) = 0;
+  virtual void VisitConditional(Conditional* conditional) = 0;
+  virtual void VisitTryCatchStatement(TryCatchStatement* try_catch_statement) = 0;
+  virtual void VisitThrow(Throw* throw_statement) = 0;
+  virtual void VisitThisExpression(ThisExpression* this_expression) = 0;
+  virtual void VisitRegExpLiteral(RegExpLiteral* reg_exp_literal) = 0;
 
   void VisitNode(AstNode* node) {
     switch (node->node_type()) {
@@ -127,11 +134,20 @@ public:
         break;
       }
 
+      case AstNode::kUnaryOperation: {
+        VisitUnaryOperation(static_cast<UnaryOperation*>(node));
+        break;
+      }
+
       case AstNode::kBinaryOperation: {
         VisitBinaryOperation(static_cast<BinaryOperation*>(node));
         break;
       }
 
+      case AstNode::kNaryOperation: {
+        VisitNaryOperation(static_cast<NaryOperation*>(node));
+        break;
+      }
       case AstNode::kObjectLiteral: {
         VisitObjectLiteral(static_cast<ObjectLiteral*>(node));
         break;
@@ -147,9 +163,33 @@ public:
         break;
       }
 
+      case AstNode::kConditional: {
+        VisitConditional(static_cast<Conditional*>(node));
+        break;
+      }
+
+      case AstNode::kTryCatchStatement: {
+        VisitTryCatchStatement(static_cast<TryCatchStatement*>(node));
+        break;
+      }
+
+      case AstNode::kThrow: {
+        VisitThrow(static_cast<Throw*>(node));
+        break;
+      }
+
+      case AstNode::kThisExpression: {
+        VisitThisExpression(static_cast<ThisExpression*>(node));
+        break;
+      }
+
+      case AstNode::kRegExpLiteral: {
+        VisitRegExpLiteral(static_cast<RegExpLiteral*>(node));
+        break;
+      }
+
       default: {
         printf("Unimplemented node type: %s\n", node->node_type_name());
-        DCHECK(false);
         break;
       }
     }


### PR DESCRIPTION
After https://github.com/mhahnenberg/v8/pull/24 we were still failing for nodes that were unimplemented on `BinAstVisitor`, so this PR removes the DCHECK that was causing that.

Also adds all of the nodes that I discovered were missing (with serialization not yet implemented) when parsing React.