### PR TITLE
store inner function offset and length inline with serialized data

### DIFF
--- a/src/codegen/compiler.cc
+++ b/src/codegen/compiler.cc
@@ -1370,11 +1370,12 @@ bool BackgroundBinAstParseTask::Finalize(Isolate* isolate, Handle<SharedFunction
     return true;
   }
   Handle<BinAstParseData> binast_parse_data = info()->literal()->produced_binast_parse_data()->Serialize(isolate);
+  Handle<ByteArray> serialized_ast = handle(binast_parse_data->serialized_ast(), isolate);
   Handle<UncompiledData> data = isolate->factory()->NewUncompiledDataWithBinAstParseData(
         info()->literal()->GetInferredName(isolate),
         info()->literal()->start_position(),
         info()->literal()->end_position(),
-        binast_parse_data);
+        serialized_ast);
   function->set_uncompiled_data(*data);
   return true;
 }
@@ -2757,6 +2758,7 @@ Handle<SharedFunctionInfo> Compiler::GetSharedFunctionInfo(
       // accurate than the literal we preparsed.
       Handle<String> inferred_name =
           handle(existing_uncompiled_data->inferred_name(), isolate);
+
       Handle<PreparseData> preparse_data =
           literal->produced_preparse_data()->Serialize(isolate);
       Handle<UncompiledData> new_uncompiled_data =

--- a/src/heap/factory-base.cc
+++ b/src/heap/factory-base.cc
@@ -313,7 +313,7 @@ template <typename Impl>
 Handle<UncompiledDataWithBinAstParseData> 
 FactoryBase<Impl>::NewUncompiledDataWithBinAstParseData(
       Handle<String> inferred_name, int32_t start_position,
-      int32_t end_position, Handle<BinAstParseData> binast_parse_data) {
+      int32_t end_position, Handle<ByteArray> binast_parse_data) {
   Handle<UncompiledDataWithBinAstParseData> result = handle(
       UncompiledDataWithBinAstParseData::cast(NewWithImmortalMap(
           impl()->read_only_roots().uncompiled_data_with_bin_ast_parse_data_map(),
@@ -322,7 +322,6 @@ FactoryBase<Impl>::NewUncompiledDataWithBinAstParseData(
 
   result->Init(impl(), *inferred_name, start_position, end_position,
                *binast_parse_data);
-
   return result;
 }
 

--- a/src/heap/factory-base.h
+++ b/src/heap/factory-base.h
@@ -141,7 +141,7 @@ class EXPORT_TEMPLATE_DECLARE(V8_EXPORT_PRIVATE) FactoryBase {
 
   Handle<UncompiledDataWithBinAstParseData> NewUncompiledDataWithBinAstParseData(
       Handle<String> inferred_name, int32_t start_position,
-      int32_t end_position, Handle<BinAstParseData>);
+      int32_t end_position, Handle<ByteArray>);
 
   // Allocates a FeedbackMedata object and zeroes the data section.
   Handle<FeedbackMetadata> NewFeedbackMetadata(

--- a/src/objects/shared-function-info-inl.h
+++ b/src/objects/shared-function-info-inl.h
@@ -86,10 +86,7 @@ TQ_OBJECT_CONSTRUCTORS_IMPL(UncompiledDataWithoutPreparseData)
 TQ_OBJECT_CONSTRUCTORS_IMPL(UncompiledDataWithPreparseData)
 TQ_OBJECT_CONSTRUCTORS_IMPL(UncompiledDataWithBinAstParseData)
 
-OBJECT_CONSTRUCTORS_IMPL(BinAstParseData, HeapObject)
-
-CAST_ACCESSOR(BinAstParseData)
-ACCESSORS(BinAstParseData, serialized_ast, ByteArray, kSerializedAstOffset)
+TQ_OBJECT_CONSTRUCTORS_IMPL(BinAstParseData)
 
 OBJECT_CONSTRUCTORS_IMPL(InterpreterData, Struct)
 
@@ -672,6 +669,7 @@ void SharedFunctionInfo::ClearBinAstParseData() {
 
   // Ensure that the clear was successful.
   DCHECK(HasUncompiledDataWithoutPreparseData());
+  DCHECK(!HasUncompiledDataWithBinAstParseData());
 }
 
 
@@ -708,7 +706,7 @@ template <typename LocalIsolate>
 void UncompiledDataWithBinAstParseData::Init(LocalIsolate* isolate,
                                           String inferred_name,
                                           int start_position, int end_position,
-                                          BinAstParseData binast_parse_data) {
+                                          ByteArray binast_parse_data) {
   this->UncompiledData::Init(isolate, inferred_name, start_position,
                              end_position);
   set_binast_parse_data(binast_parse_data);

--- a/src/objects/shared-function-info.h
+++ b/src/objects/shared-function-info.h
@@ -151,23 +151,16 @@ class UncompiledDataWithPreparseData
   TQ_OBJECT_CONSTRUCTORS(UncompiledDataWithPreparseData)
 };
 
-class BinAstParseData : public HeapObject {
+class BinAstParseData : public TorqueGeneratedBinAstParseData<BinAstParseData, HeapObject> {
  public:
-  // TODO(binast): Use a more efficient data structure for storing the serialized bytes.
-  // ByteArray uses 4-byte ints to store each byte. This was just reused initially for
-  // convenience, but to get an accurate idea of true memory use we should use something
-  // more compact.
-  DECL_ACCESSORS(serialized_ast, ByteArray)
-
-  DEFINE_FIELD_OFFSET_CONSTANTS(HeapObject::kHeaderSize,
-                                TORQUE_GENERATED_BIN_AST_PARSE_DATA_FIELDS)
-
-  using BodyDescriptor = FixedBodyDescriptor<HeapObject::kHeaderSize, kSerializedAstOffset, kSize>;
-
-  DECL_CAST(BinAstParseData)
   DECL_PRINTER(BinAstParseData)
   DECL_VERIFIER(BinAstParseData)
-  OBJECT_CONSTRUCTORS(BinAstParseData, HeapObject);
+
+  using BodyDescriptor =
+      FixedBodyDescriptor<kStartOfStrongFieldsOffset, kEndOfStrongFieldsOffset,
+                          kHeaderSize>;
+
+  TQ_OBJECT_CONSTRUCTORS(BinAstParseData)
 };
 
 // Class representing data for an uncompiled function that has a binary AST data for faster re-parsing during eager compilation.
@@ -180,7 +173,7 @@ class UncompiledDataWithBinAstParseData
   template <typename LocalIsolate>
   inline void Init(LocalIsolate* isolate, String inferred_name,
                    int start_position, int end_position,
-                   BinAstParseData scope_data);
+                   ByteArray binast_parse_data);
 
   using BodyDescriptor = SubclassBodyDescriptor<
       UncompiledData::BodyDescriptor,

--- a/src/objects/shared-function-info.tq
+++ b/src/objects/shared-function-info.tq
@@ -9,6 +9,7 @@ extern class PreparseData extends HeapObject {
   children_length: int32;
 }
 
+@generateCppClass
 extern class BinAstParseData extends HeapObject {
   serialized_ast: ByteArray;
 }
@@ -84,7 +85,7 @@ extern class UncompiledDataWithPreparseData extends UncompiledData {
 
 @generateCppClass
 extern class UncompiledDataWithBinAstParseData extends UncompiledData {
-  binast_parse_data: BinAstParseData;
+  binast_parse_data: ByteArray;
 }
 
 @export

--- a/src/parsing/abstract-parser.h
+++ b/src/parsing/abstract-parser.h
@@ -2005,13 +2005,13 @@ void AbstractParser<Impl>::ParseFunction(
 
   FunctionLiteral* result = nullptr;
   if (V8_UNLIKELY(shared_info->HasUncompiledDataWithBinAstParseData())) {
+    Handle<UncompiledDataWithBinAstParseData> uncompiled_data = handle(shared_info->uncompiled_data_with_binast_parse_data(), isolate);
+    Handle<ByteArray> binast_parse_data = handle(uncompiled_data->binast_parse_data(), isolate);
+
     RuntimeCallTimerScope runtime_timer(impl()->runtime_call_stats_,
                                       RuntimeCallCounterId::kDeserializeBinAst);
     auto start = std::chrono::high_resolution_clock::now();
-    Handle<BinAstParseData> binast_parse_data =
-        handle(shared_info->uncompiled_data_with_binast_parse_data()
-                   .binast_parse_data(),
-               isolate);
+
     FunctionLiteral* literal;
     {
       // We need to setup the parser/initial outer scope before we can start
@@ -2023,7 +2023,7 @@ void AbstractParser<Impl>::ParseFunction(
           &impl()->function_state_, &impl()->scope_, outer_function);
       typename ParserBase<Impl>::BlockState block_state(&impl()->scope_, outer);
       BinAstDeserializer deserializer(impl());
-      AstNode* ast_node = deserializer.DeserializeAst(binast_parse_data->serialized_ast());
+      AstNode* ast_node = deserializer.DeserializeAst(*binast_parse_data);
       literal = ast_node->AsFunctionLiteral();
       DCHECK(literal != nullptr);
     }

--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -60,6 +60,12 @@ BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::DeserializeA
   AstNode::NodeType nodeType = AstNode::NodeTypeField::decode(bit_field.value);
   switch (nodeType) {
   case AstNode::kFunctionLiteral: {
+    auto start_offset = DeserializeUint32(serialized_binast, offset);
+    offset = start_offset.new_offset;
+
+    auto length = DeserializeUint32(serialized_binast, offset);
+    offset = length.new_offset;
+
     auto result = DeserializeFunctionLiteral(serialized_binast, bit_field.value, position.value, offset);
     return {result.value, result.new_offset};
   }

--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -41,7 +41,8 @@ AstNode* BinAstDeserializer::DeserializeAst(ByteArray serialized_ast) {
   int offset = 0;
   auto string_table_result = DeserializeStringTable(uncompressed_byte_array.get(), offset);
   offset = string_table_result.new_offset;
-  auto result = DeserializeAstNode(uncompressed_byte_array.get(), offset, true);
+  bool is_toplevel = true;
+  auto result = DeserializeAstNode(uncompressed_byte_array.get(), offset, is_toplevel);
   // Check that we consumed all the bytes that were serialized.
   DCHECK(static_cast<size_t>(result.new_offset) == original_size);
   return result.value;

--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -14,10 +14,7 @@
 namespace v8 {
 namespace internal {
 
-BinAstDeserializer::BinAstDeserializer(Parser* parser)
-  : parser_(parser)
-{
-}
+BinAstDeserializer::BinAstDeserializer(Parser* parser) : parser_(parser) {}
 
 AstNode* BinAstDeserializer::DeserializeAst(ByteArray serialized_ast) {
   DCHECK(UseCompression() == BinAstSerializeVisitor::UseCompression());
@@ -44,13 +41,13 @@ AstNode* BinAstDeserializer::DeserializeAst(ByteArray serialized_ast) {
   int offset = 0;
   auto string_table_result = DeserializeStringTable(uncompressed_byte_array.get(), offset);
   offset = string_table_result.new_offset;
-  auto result = DeserializeAstNode(uncompressed_byte_array.get(), offset);
+  auto result = DeserializeAstNode(uncompressed_byte_array.get(), offset, true);
   // Check that we consumed all the bytes that were serialized.
   DCHECK(static_cast<size_t>(result.new_offset) == original_size);
   return result.value;
 }
 
-BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::DeserializeAstNode(uint8_t* serialized_binast, int offset) {
+BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::DeserializeAstNode(uint8_t* serialized_binast, int offset, bool is_toplevel) {
   auto bit_field = DeserializeUint32(serialized_binast, offset);
   offset = bit_field.new_offset;
 
@@ -60,11 +57,15 @@ BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::DeserializeA
   AstNode::NodeType nodeType = AstNode::NodeTypeField::decode(bit_field.value);
   switch (nodeType) {
   case AstNode::kFunctionLiteral: {
-    auto start_offset = DeserializeUint32(serialized_binast, offset);
-    offset = start_offset.new_offset;
+    base::Optional<BinAstDeserializer::DeserializeResult<uint32_t>> start_offset;
+    base::Optional<BinAstDeserializer::DeserializeResult<uint32_t>> length;
+    if (!is_toplevel) {
+      start_offset.emplace(DeserializeUint32(serialized_binast, offset));
+      offset = start_offset.value().new_offset;
 
-    auto length = DeserializeUint32(serialized_binast, offset);
-    offset = length.new_offset;
+      length.emplace(DeserializeUint32(serialized_binast, offset));
+      offset = length.value().new_offset;
+    }
 
     auto result = DeserializeFunctionLiteral(serialized_binast, bit_field.value, position.value, offset);
     return {result.value, result.new_offset};

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -68,7 +68,7 @@ class BinAstDeserializer {
   DeserializeResult<Scope*> DeserializeScope(uint8_t* serialized_binast, int offset);
   DeserializeResult<DeclarationScope*> DeserializeDeclarationScope(uint8_t* serialized_binast, int offset);
 
-  DeserializeResult<AstNode*> DeserializeAstNode(uint8_t* serialized_ast, int offset);
+  DeserializeResult<AstNode*> DeserializeAstNode(uint8_t* serialized_ast, int offset, bool is_toplevel = false);
   DeserializeResult<FunctionLiteral*> DeserializeFunctionLiteral(uint8_t* serialized_ast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<ReturnStatement*> DeserializeReturnStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<BinaryOperation*> DeserializeBinaryOperation(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -121,6 +121,7 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
 
   std::unique_ptr<uint8_t[]> compressed_byte_data_;
   size_t compressed_byte_data_length_;
+  bool at_toplevel_ = true;
 };
 
 // TODO(binast): Maybe templatize these to reduce duplication?
@@ -614,16 +615,21 @@ inline void BinAstSerializeVisitor::ToDoBinAst(AstNode* node) {
 }
 
 inline void BinAstSerializeVisitor::VisitFunctionLiteral(FunctionLiteral* function_literal) {
+  bool function_is_toplevel = at_toplevel_;
+
   size_t start = byte_data_.size();
 
   SerializeAstNodeHeader(function_literal);
 
-  DCHECK(start <= UINT32_MAX);
-  SerializeUint32(static_cast<uint32_t>(start));
+  base::Optional<size_t> length_index;
+  if (!function_is_toplevel) {
+    DCHECK(start <= UINT32_MAX);
+    SerializeUint32(static_cast<uint32_t>(start));
 
-  // make placeholder for length, save index so we can insert it later
-  auto length_index = byte_data_.size();
-  SerializeUint32(0);
+    // make placeholder for length, save index so we can insert it later
+    length_index.emplace(byte_data_.size());
+    SerializeUint32(0);
+  }
 
   const AstConsString* name = function_literal->raw_name();
   SerializeConsString(name);
@@ -638,14 +644,19 @@ inline void BinAstSerializeVisitor::VisitFunctionLiteral(FunctionLiteral* functi
 
   SerializeInt32(function_literal->body()->length());
   for (Statement* statement : *function_literal->body()) {
+    if (at_toplevel_) {
+      at_toplevel_ = false;
+    }
     VisitNode(statement);
   }
 
-  // Calculate length and insert at length_index
-  auto length = byte_data_.size() - start;
-  auto offset = byte_data_.size() - length_index;
-  DCHECK(length <= UINT32_MAX);
-  SerializeUint32(static_cast<uint32_t>(length), offset);
+  if (!function_is_toplevel) {
+    // Calculate length and insert at length_index
+    auto length = byte_data_.size() - start;
+    auto offset = byte_data_.size() - length_index.value();
+    DCHECK(length <= UINT32_MAX);
+    SerializeUint32(static_cast<uint32_t>(length), offset);
+  }
 }
 
 inline void BinAstSerializeVisitor::VisitBlock(Block* block) {

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -143,7 +143,8 @@ inline void BinAstSerializeVisitor::SerializeUint64(uint64_t value) {
 
 inline void BinAstSerializeVisitor::SerializeUint32(
     uint32_t value, const base::Optional<size_t> index = base::nullopt) {
-  // DCHECK(index >= 0 && index <= byte_data_.size());
+  DCHECK(!index.has_value() ||
+         (index.value() >= 0 && index <= byte_data_.size()));
   for (size_t i = 0; i < sizeof(uint32_t) / sizeof(uint8_t); ++i) {
     size_t shift = sizeof(uint8_t) * 8 * i;
     uint32_t mask = 0xff << shift;

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -141,8 +141,8 @@ inline void BinAstSerializeVisitor::SerializeUint64(uint64_t value) {
   }
 }
 
-inline void BinAstSerializeVisitor::SerializeUint32(uint32_t value, size_t offset) {
-  DCHECK(offset >= 0 && offset <= byte_data_.size());
+inline void BinAstSerializeVisitor::SerializeUint32(uint32_t value, size_t index) {
+  DCHECK(index >= 0 && index <= byte_data_.size());
   for (size_t i = 0; i < sizeof(uint32_t) / sizeof(uint8_t); ++i) {
     size_t shift = sizeof(uint8_t) * 8 * i;
     uint32_t mask = 0xff << shift;
@@ -151,10 +151,10 @@ inline void BinAstSerializeVisitor::SerializeUint32(uint32_t value, size_t offse
     DCHECK(final_value <= 0xff);
     uint8_t truncated_final_value = final_value;
 
-    if (offset == 0) {
+    if (index == 0) {
       byte_data_.push_back(truncated_final_value);
     } else {
-      byte_data_[byte_data_.size() - 1 - offset] = truncated_final_value;
+      byte_data_[index + i] = truncated_final_value;
     }
   }
 }
@@ -653,9 +653,8 @@ inline void BinAstSerializeVisitor::VisitFunctionLiteral(FunctionLiteral* functi
   if (!function_is_toplevel) {
     // Calculate length and insert at length_index
     auto length = byte_data_.size() - start;
-    auto offset = byte_data_.size() - length_index.value();
     DCHECK(length <= UINT32_MAX);
-    SerializeUint32(static_cast<uint32_t>(length), offset);
+    SerializeUint32(static_cast<uint32_t>(length), length_index.value());
   }
 }
 

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -608,7 +608,16 @@ inline void BinAstSerializeVisitor::ToDoBinAst(AstNode* node) {
 }
 
 inline void BinAstSerializeVisitor::VisitFunctionLiteral(FunctionLiteral* function_literal) {
+  size_t start = byte_data_.size();
+
   SerializeAstNodeHeader(function_literal);
+
+  SerializeUint32(static_cast<int>(start));
+
+  // make placeholder for length, save index so we can insert it later
+  auto length_index = byte_data_.size();
+  SerializeUint32(0);
+
   const AstConsString* name = function_literal->raw_name();
   SerializeConsString(name);
   SerializeDeclarationScope(function_literal->scope());
@@ -623,6 +632,18 @@ inline void BinAstSerializeVisitor::VisitFunctionLiteral(FunctionLiteral* functi
   SerializeInt32(function_literal->body()->length());
   for (Statement* statement : *function_literal->body()) {
     VisitNode(statement);
+  }
+
+  // Calculate length and insert at length_index
+  auto length = byte_data_.size() - start;
+  for (size_t i = 0; i < sizeof(uint32_t) / sizeof(uint8_t); ++i) {
+    size_t shift = sizeof(uint8_t) * 8 * i;
+    uint32_t mask = 0xff << shift;
+    uint32_t masked_value = length & mask;
+    uint32_t final_value = masked_value >> shift;
+    DCHECK(final_value <= 0xff);
+    uint8_t truncated_final_value = final_value;
+    byte_data_[length_index + i] = truncated_final_value;
   }
 }
 

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -77,6 +77,7 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   virtual void VisitThisExpression(ThisExpression* this_expression) override;
   virtual void VisitRegExpLiteral(RegExpLiteral* reg_exp_literal) override;
   virtual void VisitSwitchStatement(SwitchStatement* switch_statement) override;
+  virtual void VisitUnhandledNodeType(AstNode* node) override;
 
  private:
   friend class BinAstDeserializer;
@@ -234,6 +235,7 @@ inline void BinAstSerializeVisitor::SerializeVarUint32(uint32_t value) {
 inline void BinAstSerializeVisitor::SerializeRawString(const AstRawString* s) {
   DCHECK(s != nullptr);
   DCHECK(string_table_indices_.count(s) == 0);
+  DCHECK(s->byte_length() >= 0);
   uint32_t length = s->byte_length();
   bool is_one_byte = s->is_one_byte();
   uint32_t hash_field = s->hash_field();
@@ -295,7 +297,9 @@ inline void BinAstSerializeVisitor::SerializeStringTable(const AstConsString* fu
       }
     }
   }
-  SerializeUint32(num_entries - num_constant_entries);
+  uint32_t num_non_constant_entries = num_entries - num_constant_entries;
+  DCHECK(num_entries >= num_constant_entries);
+  SerializeUint32(num_non_constant_entries);
   uint32_t current_index = 1;
   // Insert non-constant strings
   for (base::HashMap::Entry* entry = ast_value_factory_->string_table_.Start(); entry != nullptr; entry = ast_value_factory_->string_table_.Next(entry)) {
@@ -309,13 +313,7 @@ inline void BinAstSerializeVisitor::SerializeStringTable(const AstConsString* fu
     string_table_indices_.insert({s, current_index});
     current_index += 1;
   }
-
-  // Only insert constant strings into the table (i.e. don't serialize their contents)
-  for (base::HashMap::Entry* entry = ast_value_factory_->string_constants_->string_table()->Start(); entry != nullptr; entry = ast_value_factory_->string_constants_->string_table()->Next(entry)) {
-    const AstRawString* s = reinterpret_cast<const AstRawString*>(entry->key);
-    string_table_indices_.insert({s, current_index});
-    current_index += 1;
-  }
+  DCHECK(current_index - 1 == num_non_constant_entries);
 
   if (function_name != nullptr) {
     for (const AstRawString* s : function_name->ToRawStrings()) {
@@ -326,6 +324,13 @@ inline void BinAstSerializeVisitor::SerializeStringTable(const AstConsString* fu
         current_index += 1;
       }
     }
+  }
+
+  // Only insert constant strings into the table (i.e. don't serialize their contents)
+  for (base::HashMap::Entry* entry = ast_value_factory_->string_constants_->string_table()->Start(); entry != nullptr; entry = ast_value_factory_->string_constants_->string_table()->Next(entry)) {
+    const AstRawString* s = reinterpret_cast<const AstRawString*>(entry->key);
+    string_table_indices_.insert({s, current_index});
+    current_index += 1;
   }
 
   DCHECK(current_index == num_entries + 1);
@@ -835,6 +840,11 @@ inline void BinAstSerializeVisitor::VisitSwitchStatement(
     SwitchStatement* switch_statement) {
   SerializeAstNodeHeader(switch_statement);
   ToDoBinAst(switch_statement);
+}
+
+inline void BinAstSerializeVisitor::VisitUnhandledNodeType(AstNode* node) {
+  SerializeAstNodeHeader(node);
+  ToDoBinAst(node);
 }
 
 }  // namespace internal

--- a/src/parsing/binast-visitor.h
+++ b/src/parsing/binast-visitor.h
@@ -42,6 +42,7 @@ public:
   virtual void VisitThisExpression(ThisExpression* this_expression) = 0;
   virtual void VisitRegExpLiteral(RegExpLiteral* reg_exp_literal) = 0;
   virtual void VisitSwitchStatement(SwitchStatement* switch_statement) = 0;
+  virtual void VisitUnhandledNodeType(AstNode* node) = 0;
 
   void VisitNode(AstNode* node) {
     DCHECK_NOT_NULL(node);
@@ -197,6 +198,7 @@ public:
 
       default: {
         printf("Unimplemented node type: %s\n", node->node_type_name());
+        VisitUnhandledNodeType(node);
         break;
       }
     }


### PR DESCRIPTION
adds serialization and deserialization of inner function offsets and lengths

also removes preparsing logic from BinAstParser - i don't think we want to skip functions in that context?

will follow up with PR actually utilizing these offsets