### PR TITLE
Fix several bugs in AST de/serialization logic

### DIFF
--- a/src/parsing/abstract-parser.h
+++ b/src/parsing/abstract-parser.h
@@ -2022,7 +2022,7 @@ void AbstractParser<Impl>::ParseFunction(
       typename ParserBase<Impl>::FunctionState function_state(
           &impl()->function_state_, &impl()->scope_, outer_function);
       typename ParserBase<Impl>::BlockState block_state(&impl()->scope_, outer);
-      BinAstDeserializer deserializer(impl(), outer);
+      BinAstDeserializer deserializer(impl());
       AstNode* ast_node = deserializer.DeserializeAst(binast_parse_data->serialized_ast());
       literal = ast_node->AsFunctionLiteral();
       DCHECK(literal != nullptr);

--- a/src/parsing/binast-deserializer-inl.h
+++ b/src/parsing/binast-deserializer-inl.h
@@ -400,7 +400,7 @@ inline BinAstDeserializer::DeserializeResult<Literal*> BinAstDeserializer::Deser
       break;
     }
     case Literal::kBoolean: {
-      auto boolean = DeserializeUint8(serialized_binast, position);
+      auto boolean = DeserializeUint8(serialized_binast, offset);
       offset = boolean.new_offset;
       result = parser_->factory()->NewBooleanLiteral(boolean.value, position);
       break;
@@ -421,7 +421,7 @@ inline BinAstDeserializer::DeserializeResult<Literal*> BinAstDeserializer::Deser
       UNREACHABLE();
     }
   }
-  DCHECK(result->bit_field_ == bit_field);
+  result->bit_field_ = bit_field;
 
   return {result, offset};
 }

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -21,7 +21,7 @@ class Parser;
 
 class BinAstDeserializer {
  public:
-  BinAstDeserializer(Parser* parser, Scope* outer_scope);
+  BinAstDeserializer(Parser* parser);
 
   AstNode* DeserializeAst(ByteArray serialized_ast);
 
@@ -34,6 +34,8 @@ class BinAstDeserializer {
 
   Zone* zone();
   static bool UseCompression() { return false; }
+
+  DeserializeResult<AstNode*> DeserializeMaybeAstNode(uint8_t* serialized_binast, int offset);
 
   DeserializeResult<uint64_t> DeserializeUint64(uint8_t* bytes, int offset);
   DeserializeResult<uint32_t> DeserializeUint32(uint8_t* bytes, int offset);

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -108,6 +108,7 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   void SerializeAstNodeHeader(AstNode* node);
   void SerializeVariableProxy(VariableProxy* proxy);
 
+  void VisitMaybeNode(AstNode* maybe_node);
   void ToDoBinAst(AstNode* node);
 
   AstValueFactory* ast_value_factory_;
@@ -529,7 +530,10 @@ inline void BinAstSerializeVisitor::SerializeDeclarationScope(DeclarationScope* 
 
   SerializeScopeParameters(scope);
   // TODO(binast): sloppy_block_functions_ (needed for non-strict mode support)
-  DCHECK(scope->sloppy_block_functions_.is_empty());
+  if (!scope->sloppy_block_functions_.is_empty()) {
+    printf("BinAstSerializeVisitor encountered unsupported sloppy block functions on DeclarationScope\n");
+    encountered_unhandled_node_ = true;
+  }
 
   SerializeVariableOrReference(scope->receiver_);
   SerializeVariableOrReference(scope->function_);
@@ -537,7 +541,7 @@ inline void BinAstSerializeVisitor::SerializeDeclarationScope(DeclarationScope* 
   SerializeVariableOrReference(scope->arguments_);
 
   // TODO(binast): rare_data_ (needed for > ES5.1 feature support)
-  if (scope->rare_data_ == nullptr) {
+  if (scope->rare_data_ != nullptr) {
     printf("BinAstSerializeVisitor encountered unsupported rare data on DeclarationScope\n");
     encountered_unhandled_node_ = true;
   }
@@ -564,6 +568,15 @@ inline void BinAstSerializeVisitor::SerializeVariableProxy(VariableProxy* proxy)
     SerializeVariableOrReference(proxy->var());
   } else {
     SerializeRawStringReference(proxy->raw_name());
+  }
+}
+
+inline void BinAstSerializeVisitor::VisitMaybeNode(AstNode* maybe_node) {
+  if (maybe_node) {
+    SerializeUint8(1);
+    VisitNode(maybe_node);
+  } else {
+    SerializeUint8(0);
   }
 }
 
@@ -677,26 +690,9 @@ inline void BinAstSerializeVisitor::VisitForStatement(ForStatement* for_statemen
   SerializeAstNodeHeader(for_statement);
 
   // TODO(binast): are we guaranteed that we'll have all of these nodes?
-  if (for_statement->init()) {
-    SerializeUint8(1);
-    VisitNode(for_statement->init());
-  } else {
-    SerializeUint8(0);
-  }
-
-  if (for_statement->cond()) {
-    SerializeUint8(1);
-    VisitNode(for_statement->cond());
-  } else {
-    SerializeUint8(0);
-  }
-
-  if (for_statement->next()) {
-    SerializeUint8(1);
-    VisitNode(for_statement->next());
-  } else {
-    SerializeUint8(0);
-  }
+  VisitMaybeNode(for_statement->init());
+  VisitMaybeNode(for_statement->cond());
+  VisitMaybeNode(for_statement->next());
 
   VisitNode(for_statement->body());
 }

--- a/src/parsing/binast-visitor.h
+++ b/src/parsing/binast-visitor.h
@@ -44,6 +44,7 @@ public:
   virtual void VisitSwitchStatement(SwitchStatement* switch_statement) = 0;
 
   void VisitNode(AstNode* node) {
+    DCHECK_NOT_NULL(node);
     switch (node->node_type()) {
       case AstNode::kFunctionLiteral: {
         VisitFunctionLiteral(static_cast<FunctionLiteral*>(node));

--- a/test/binast/test.js
+++ b/test/binast/test.js
@@ -1,5 +1,20 @@
 'use strict';
 
+function Thing() {
+  this.$ = {foo: null, bar: null};
+}
+
+Thing.prototype.ready = function() {
+  this.$.foo = 'foo';
+  this.$.bar = false;
+};
+
+function makeThing() {
+  var t = new Thing();
+  t.ready();
+  return t;
+}
+
 var double = function(x) { return x * 2; }
 function triple(x) { return x * 3; }
 function deep() {
@@ -125,6 +140,7 @@ setTimeout(function testCallback2() {
   console.log(sumForIn([1,2,3,4,5,6,7,8,9,10]));
   console.log(sumWhile(10));
   console.log(sumDoWhile(10));
+  console.log(makeThing());
 }, 5000);
 
 tickRunLoop();


### PR DESCRIPTION
This diff fixes a number of bugs encountered when trying to run the
speculative parser on real websites.

1) We had inverted the condition for excluding ASTs with DeclarationScopes
that had rare data objects. This led to exluding most of the functions we
*could* have serialized, and only serializing those which we actually didn't
support.
2) There was an off-by-one error in reading the flag fields for DeclarationScopes
which led to us incorrectly treating loading from "this", which caused downstream
mismatches in the generated bytecode, among other things.
3) Expression has a bit field (is_parenthesized) that isn't set by default when
creating new AstNodes that are subtypes of Expression. This would lead to bit_field
mismatches, which we had added DCHECKs for. We now instead explicitly overwrite
the bit_field with whatever we deserialized to ensure that they match and to prevent
this kind of issue in the future.
4) There was a typo where we were passing the source position as the offset when
deserializing boolean literals, causing downstream misinterpretation due to a newly
misaligned offset into the serialized byte array.