### PR TITLE
Fix de/serialization for Declarations

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -410,6 +410,7 @@ class VariableDeclaration : public Declaration {
  private:
   friend class AstNodeFactory;
   friend class BinAstNodeFactory;
+  friend class BinAstDeserializer;
 
  protected:
   explicit VariableDeclaration(int pos, bool is_nested = false)
@@ -430,6 +431,7 @@ class NestedVariableDeclaration final : public VariableDeclaration {
  private:
   friend class AstNodeFactory;
   friend class BinAstNodeFactory;
+  friend class BinAstDeserializer;
 
   NestedVariableDeclaration(Scope* scope, int pos)
       : VariableDeclaration(pos, true), scope_(scope) {}
@@ -449,6 +451,7 @@ class FunctionDeclaration final : public Declaration {
  private:
   friend class AstNodeFactory;
   friend class BinAstNodeFactory;
+  friend class BinAstDeserializer;
 
   FunctionDeclaration(void* fun, int pos)
       : Declaration(pos, Declaration::FunctionDecl), fun_(fun) {}

--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -218,9 +218,30 @@ BinAstDeserializer::DeserializeResult<Declaration*> BinAstDeserializer::Deserial
   auto variable = DeserializeVariableReference(serialized_binast, offset);
   offset = variable.new_offset;
 
-  Declaration* decl = new (zone()) Declaration(start_pos.value, static_cast<Declaration::DeclType>(decl_type.value));
-  decl->set_var(variable.value);
-  return {decl, offset};
+  Declaration* result;
+  switch (decl_type.value) {
+    case Declaration::DeclType::VariableDecl: {
+      auto is_nested = DeserializeUint8(serialized_binast, offset);
+      offset = is_nested.new_offset;
+
+      // TODO(binast): Add support for nested var decls.
+      DCHECK(!is_nested.value);
+      result = new (zone()) VariableDeclaration(start_pos.value, is_nested.value);
+      break;
+    }
+    case Declaration::DeclType::FunctionDecl: {
+      auto func = DeserializeAstNode(serialized_binast, offset);
+      offset = func.new_offset;
+
+      result = new (zone()) FunctionDeclaration((void*)func.value, start_pos.value);
+      break;
+    }
+    default: {
+      UNREACHABLE();
+    }
+  }
+  result->set_var(variable.value);
+  return {result, offset};
 }
 
 BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::DeserializeScopeDeclarations(uint8_t* serialized_binast, int offset, Scope* scope) {

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -429,6 +429,21 @@ inline void BinAstSerializeVisitor::SerializeDeclaration(Scope* scope, Declarati
   SerializeInt32(decl->position());
   SerializeUint8(decl->type());
   SerializeVariableReference(decl->var());
+  switch(decl->type()) {
+    case Declaration::DeclType::VariableDecl: {
+      // TODO(binast): Add support for nested variable declarations.
+      if (decl->AsVariableDeclaration()->is_nested()) {
+        encountered_unhandled_node_ = true;
+        printf("BinAstSerializeVisitor encountered unhandled nested variable declaration, skipping function\n");
+      }
+      SerializeUint8(decl->AsVariableDeclaration()->is_nested());
+      break;
+    }
+    case Declaration::DeclType::FunctionDecl: {
+      VisitNode(decl->AsFunctionDeclaration()->fun<FunctionLiteral>());
+      break;
+    }
+  }
 }
 
 inline void BinAstSerializeVisitor::SerializeScopeDeclarations(Scope* scope) {


### PR DESCRIPTION
We were just de/serializing the fields of the Declaration base class.
The subclasses VariableDeclaration and FunctionDeclaration had additional
data (including a FunctionLiteral in the case of FunctionDeclarations)
that needed de/serialization.