### PR TITLE
Fix deserialization of FunctionDeclarations to properly handle scope …

### DIFF
--- a/src/objects/objects-body-descriptors-inl.h
+++ b/src/objects/objects-body-descriptors-inl.h
@@ -1080,6 +1080,11 @@ ReturnType BodyDescriptorApply(InstanceType type, T1 p1, T2 p2, T3 p3, T4 p4) {
     case UNCOMPILED_DATA_WITH_PREPARSE_DATA_TYPE:
       return Op::template apply<UncompiledDataWithPreparseData::BodyDescriptor>(
           p1, p2, p3, p4);
+    case UNCOMPILED_DATA_WITH_BIN_AST_PARSE_DATA_TYPE:
+      return Op::template apply<UncompiledDataWithBinAstParseData::BodyDescriptor>(
+          p1, p2, p3, p4);
+    case BIN_AST_PARSE_DATA_TYPE:
+      return Op::template apply<BinAstParseData::BodyDescriptor>(p1, p2, p3, p4);
     case HEAP_NUMBER_TYPE:
     case FILLER_TYPE:
     case BYTE_ARRAY_TYPE:

--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -230,6 +230,9 @@ BinAstDeserializer::DeserializeResult<Declaration*> BinAstDeserializer::Deserial
       break;
     }
     case Declaration::DeclType::FunctionDecl: {
+      // We need to push the Scope being currently deserialized onto the Scope stack while deserializing
+      // the FunctionLiterals inside FunctionDeclarations, otherwise their scope chain will end up skipping it.
+      Parser::FunctionState function_state(&parser_->function_state_, &parser_->scope_, scope->AsDeclarationScope());
       auto func = DeserializeAstNode(serialized_binast, offset);
       offset = func.new_offset;
 
@@ -377,7 +380,7 @@ BinAstDeserializer::DeserializeResult<DeclarationScope*> BinAstDeserializer::Des
   offset = scope_type.new_offset;
 
   switch (scope_type.value) {
-    case CLASS_SCOPE: 
+    case CLASS_SCOPE:
     case EVAL_SCOPE:
     case MODULE_SCOPE:
     case SCRIPT_SCOPE:

--- a/test/binast/test.js
+++ b/test/binast/test.js
@@ -15,6 +15,8 @@ function makeThing() {
   return t;
 }
 
+function explode2(a,b,c,d,e,f){"use strict";e.exports=a;function a(){return b;}}
+
 var double = function(x) { return x * 2; }
 function triple(x) { return x * 3; }
 function deep() {
@@ -141,6 +143,14 @@ setTimeout(function testCallback2() {
   console.log(sumWhile(10));
   console.log(sumDoWhile(10));
   console.log(makeThing());
+  var a = 0;
+  var b = 'sweet!';
+  var c = 2;
+  var d = 3;
+  var e = {};
+  console.log(explode2(a, b, c, d, e));
+  console.log(e);
+  console.log(e.exports());
 }, 5000);
 
 tickRunLoop();


### PR DESCRIPTION
…chain

We were deserializing the FunctionLiterals inside FunctionDeclarations as
part of the deserialization of the DeclarationScope. The scope being currently
deserialized needed to be in the scope chain of the resulting FunctionLiteral,
but it wasn't the active scope. This diff adds a usage of FunctionState to
push the scope onto the scope stack so it is properly referenced by the FunctionLiteral.

Also fixes a random GC crash due to not handling BinAstParseData and friend
inside a switch statement for object descriptors.