### PR TITLE
Fix a few more bugs related to speculative parsing de/serialization

### DIFF
--- a/src/codegen/compiler.cc
+++ b/src/codegen/compiler.cc
@@ -1370,11 +1370,12 @@ bool BackgroundBinAstParseTask::Finalize(Isolate* isolate, Handle<SharedFunction
     return true;
   }
   Handle<BinAstParseData> binast_parse_data = info()->literal()->produced_binast_parse_data()->Serialize(isolate);
+  Handle<ByteArray> serialized_ast = handle(binast_parse_data->serialized_ast(), isolate);
   Handle<UncompiledData> data = isolate->factory()->NewUncompiledDataWithBinAstParseData(
         info()->literal()->GetInferredName(isolate),
         info()->literal()->start_position(),
         info()->literal()->end_position(),
-        binast_parse_data);
+        serialized_ast);
   function->set_uncompiled_data(*data);
   return true;
 }
@@ -2757,6 +2758,7 @@ Handle<SharedFunctionInfo> Compiler::GetSharedFunctionInfo(
       // accurate than the literal we preparsed.
       Handle<String> inferred_name =
           handle(existing_uncompiled_data->inferred_name(), isolate);
+
       Handle<PreparseData> preparse_data =
           literal->produced_preparse_data()->Serialize(isolate);
       Handle<UncompiledData> new_uncompiled_data =

--- a/src/heap/factory-base.cc
+++ b/src/heap/factory-base.cc
@@ -313,7 +313,7 @@ template <typename Impl>
 Handle<UncompiledDataWithBinAstParseData> 
 FactoryBase<Impl>::NewUncompiledDataWithBinAstParseData(
       Handle<String> inferred_name, int32_t start_position,
-      int32_t end_position, Handle<BinAstParseData> binast_parse_data) {
+      int32_t end_position, Handle<ByteArray> binast_parse_data) {
   Handle<UncompiledDataWithBinAstParseData> result = handle(
       UncompiledDataWithBinAstParseData::cast(NewWithImmortalMap(
           impl()->read_only_roots().uncompiled_data_with_bin_ast_parse_data_map(),
@@ -322,7 +322,6 @@ FactoryBase<Impl>::NewUncompiledDataWithBinAstParseData(
 
   result->Init(impl(), *inferred_name, start_position, end_position,
                *binast_parse_data);
-
   return result;
 }
 

--- a/src/heap/factory-base.h
+++ b/src/heap/factory-base.h
@@ -141,7 +141,7 @@ class EXPORT_TEMPLATE_DECLARE(V8_EXPORT_PRIVATE) FactoryBase {
 
   Handle<UncompiledDataWithBinAstParseData> NewUncompiledDataWithBinAstParseData(
       Handle<String> inferred_name, int32_t start_position,
-      int32_t end_position, Handle<BinAstParseData>);
+      int32_t end_position, Handle<ByteArray>);
 
   // Allocates a FeedbackMedata object and zeroes the data section.
   Handle<FeedbackMetadata> NewFeedbackMetadata(

--- a/src/objects/shared-function-info-inl.h
+++ b/src/objects/shared-function-info-inl.h
@@ -86,10 +86,7 @@ TQ_OBJECT_CONSTRUCTORS_IMPL(UncompiledDataWithoutPreparseData)
 TQ_OBJECT_CONSTRUCTORS_IMPL(UncompiledDataWithPreparseData)
 TQ_OBJECT_CONSTRUCTORS_IMPL(UncompiledDataWithBinAstParseData)
 
-OBJECT_CONSTRUCTORS_IMPL(BinAstParseData, HeapObject)
-
-CAST_ACCESSOR(BinAstParseData)
-ACCESSORS(BinAstParseData, serialized_ast, ByteArray, kSerializedAstOffset)
+TQ_OBJECT_CONSTRUCTORS_IMPL(BinAstParseData)
 
 OBJECT_CONSTRUCTORS_IMPL(InterpreterData, Struct)
 
@@ -672,6 +669,7 @@ void SharedFunctionInfo::ClearBinAstParseData() {
 
   // Ensure that the clear was successful.
   DCHECK(HasUncompiledDataWithoutPreparseData());
+  DCHECK(!HasUncompiledDataWithBinAstParseData());
 }
 
 
@@ -708,7 +706,7 @@ template <typename LocalIsolate>
 void UncompiledDataWithBinAstParseData::Init(LocalIsolate* isolate,
                                           String inferred_name,
                                           int start_position, int end_position,
-                                          BinAstParseData binast_parse_data) {
+                                          ByteArray binast_parse_data) {
   this->UncompiledData::Init(isolate, inferred_name, start_position,
                              end_position);
   set_binast_parse_data(binast_parse_data);

--- a/src/objects/shared-function-info.h
+++ b/src/objects/shared-function-info.h
@@ -151,23 +151,16 @@ class UncompiledDataWithPreparseData
   TQ_OBJECT_CONSTRUCTORS(UncompiledDataWithPreparseData)
 };
 
-class BinAstParseData : public HeapObject {
+class BinAstParseData : public TorqueGeneratedBinAstParseData<BinAstParseData, HeapObject> {
  public:
-  // TODO(binast): Use a more efficient data structure for storing the serialized bytes.
-  // ByteArray uses 4-byte ints to store each byte. This was just reused initially for
-  // convenience, but to get an accurate idea of true memory use we should use something
-  // more compact.
-  DECL_ACCESSORS(serialized_ast, ByteArray)
-
-  DEFINE_FIELD_OFFSET_CONSTANTS(HeapObject::kHeaderSize,
-                                TORQUE_GENERATED_BIN_AST_PARSE_DATA_FIELDS)
-
-  using BodyDescriptor = FixedBodyDescriptor<HeapObject::kHeaderSize, kSerializedAstOffset, kSize>;
-
-  DECL_CAST(BinAstParseData)
   DECL_PRINTER(BinAstParseData)
   DECL_VERIFIER(BinAstParseData)
-  OBJECT_CONSTRUCTORS(BinAstParseData, HeapObject);
+
+  using BodyDescriptor =
+      FixedBodyDescriptor<kStartOfStrongFieldsOffset, kEndOfStrongFieldsOffset,
+                          kHeaderSize>;
+
+  TQ_OBJECT_CONSTRUCTORS(BinAstParseData)
 };
 
 // Class representing data for an uncompiled function that has a binary AST data for faster re-parsing during eager compilation.
@@ -180,7 +173,7 @@ class UncompiledDataWithBinAstParseData
   template <typename LocalIsolate>
   inline void Init(LocalIsolate* isolate, String inferred_name,
                    int start_position, int end_position,
-                   BinAstParseData scope_data);
+                   ByteArray binast_parse_data);
 
   using BodyDescriptor = SubclassBodyDescriptor<
       UncompiledData::BodyDescriptor,

--- a/src/objects/shared-function-info.tq
+++ b/src/objects/shared-function-info.tq
@@ -9,6 +9,7 @@ extern class PreparseData extends HeapObject {
   children_length: int32;
 }
 
+@generateCppClass
 extern class BinAstParseData extends HeapObject {
   serialized_ast: ByteArray;
 }
@@ -84,7 +85,7 @@ extern class UncompiledDataWithPreparseData extends UncompiledData {
 
 @generateCppClass
 extern class UncompiledDataWithBinAstParseData extends UncompiledData {
-  binast_parse_data: BinAstParseData;
+  binast_parse_data: ByteArray;
 }
 
 @export

--- a/src/parsing/abstract-parser.h
+++ b/src/parsing/abstract-parser.h
@@ -2005,13 +2005,13 @@ void AbstractParser<Impl>::ParseFunction(
 
   FunctionLiteral* result = nullptr;
   if (V8_UNLIKELY(shared_info->HasUncompiledDataWithBinAstParseData())) {
+    Handle<UncompiledDataWithBinAstParseData> uncompiled_data = handle(shared_info->uncompiled_data_with_binast_parse_data(), isolate);
+    Handle<ByteArray> binast_parse_data = handle(uncompiled_data->binast_parse_data(), isolate);
+
     RuntimeCallTimerScope runtime_timer(impl()->runtime_call_stats_,
                                       RuntimeCallCounterId::kDeserializeBinAst);
     auto start = std::chrono::high_resolution_clock::now();
-    Handle<BinAstParseData> binast_parse_data =
-        handle(shared_info->uncompiled_data_with_binast_parse_data()
-                   .binast_parse_data(),
-               isolate);
+
     FunctionLiteral* literal;
     {
       // We need to setup the parser/initial outer scope before we can start
@@ -2023,7 +2023,7 @@ void AbstractParser<Impl>::ParseFunction(
           &impl()->function_state_, &impl()->scope_, outer_function);
       typename ParserBase<Impl>::BlockState block_state(&impl()->scope_, outer);
       BinAstDeserializer deserializer(impl());
-      AstNode* ast_node = deserializer.DeserializeAst(binast_parse_data->serialized_ast());
+      AstNode* ast_node = deserializer.DeserializeAst(*binast_parse_data);
       literal = ast_node->AsFunctionLiteral();
       DCHECK(literal != nullptr);
     }

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -77,6 +77,7 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   virtual void VisitThisExpression(ThisExpression* this_expression) override;
   virtual void VisitRegExpLiteral(RegExpLiteral* reg_exp_literal) override;
   virtual void VisitSwitchStatement(SwitchStatement* switch_statement) override;
+  virtual void VisitUnhandledNodeType(AstNode* node) override;
 
  private:
   friend class BinAstDeserializer;
@@ -234,6 +235,7 @@ inline void BinAstSerializeVisitor::SerializeVarUint32(uint32_t value) {
 inline void BinAstSerializeVisitor::SerializeRawString(const AstRawString* s) {
   DCHECK(s != nullptr);
   DCHECK(string_table_indices_.count(s) == 0);
+  DCHECK(s->byte_length() >= 0);
   uint32_t length = s->byte_length();
   bool is_one_byte = s->is_one_byte();
   uint32_t hash_field = s->hash_field();
@@ -295,7 +297,9 @@ inline void BinAstSerializeVisitor::SerializeStringTable(const AstConsString* fu
       }
     }
   }
-  SerializeUint32(num_entries - num_constant_entries);
+  uint32_t num_non_constant_entries = num_entries - num_constant_entries;
+  DCHECK(num_entries >= num_constant_entries);
+  SerializeUint32(num_non_constant_entries);
   uint32_t current_index = 1;
   // Insert non-constant strings
   for (base::HashMap::Entry* entry = ast_value_factory_->string_table_.Start(); entry != nullptr; entry = ast_value_factory_->string_table_.Next(entry)) {
@@ -309,13 +313,7 @@ inline void BinAstSerializeVisitor::SerializeStringTable(const AstConsString* fu
     string_table_indices_.insert({s, current_index});
     current_index += 1;
   }
-
-  // Only insert constant strings into the table (i.e. don't serialize their contents)
-  for (base::HashMap::Entry* entry = ast_value_factory_->string_constants_->string_table()->Start(); entry != nullptr; entry = ast_value_factory_->string_constants_->string_table()->Next(entry)) {
-    const AstRawString* s = reinterpret_cast<const AstRawString*>(entry->key);
-    string_table_indices_.insert({s, current_index});
-    current_index += 1;
-  }
+  DCHECK(current_index - 1 == num_non_constant_entries);
 
   if (function_name != nullptr) {
     for (const AstRawString* s : function_name->ToRawStrings()) {
@@ -326,6 +324,13 @@ inline void BinAstSerializeVisitor::SerializeStringTable(const AstConsString* fu
         current_index += 1;
       }
     }
+  }
+
+  // Only insert constant strings into the table (i.e. don't serialize their contents)
+  for (base::HashMap::Entry* entry = ast_value_factory_->string_constants_->string_table()->Start(); entry != nullptr; entry = ast_value_factory_->string_constants_->string_table()->Next(entry)) {
+    const AstRawString* s = reinterpret_cast<const AstRawString*>(entry->key);
+    string_table_indices_.insert({s, current_index});
+    current_index += 1;
   }
 
   DCHECK(current_index == num_entries + 1);
@@ -835,6 +840,11 @@ inline void BinAstSerializeVisitor::VisitSwitchStatement(
     SwitchStatement* switch_statement) {
   SerializeAstNodeHeader(switch_statement);
   ToDoBinAst(switch_statement);
+}
+
+inline void BinAstSerializeVisitor::VisitUnhandledNodeType(AstNode* node) {
+  SerializeAstNodeHeader(node);
+  ToDoBinAst(node);
 }
 
 }  // namespace internal

--- a/src/parsing/binast-visitor.h
+++ b/src/parsing/binast-visitor.h
@@ -42,6 +42,7 @@ public:
   virtual void VisitThisExpression(ThisExpression* this_expression) = 0;
   virtual void VisitRegExpLiteral(RegExpLiteral* reg_exp_literal) = 0;
   virtual void VisitSwitchStatement(SwitchStatement* switch_statement) = 0;
+  virtual void VisitUnhandledNodeType(AstNode* node) = 0;
 
   void VisitNode(AstNode* node) {
     DCHECK_NOT_NULL(node);
@@ -197,6 +198,7 @@ public:
 
       default: {
         printf("Unimplemented node type: %s\n", node->node_type_name());
+        VisitUnhandledNodeType(node);
         break;
       }
     }


### PR DESCRIPTION
* We weren't properly marking encountered_handle_node_ for AST nodes that
  weren't properly supported by the BinAstVisitor. This led to us trying to
  deserialize incomplete ASTs and throwing bizarre errors down the road.
* We had an extra object between the UncompiledDataWithBinAstParseData and the
  ByteArray with the serialized AST. There was something wrong with GC semantics
  of this object which caused it to fail to properly mark the ByteArray, leading
  to later derefs of invalid memory during deserialization.
* We were serializing the pieces of the string table (namely constants) in the
  slightly wrong order which was causing some strings to be incorrectly referenced.