### PR TITLE
De/serialize ObjectLiteral

### DIFF
--- a/src/parsing/abstract-parser.h
+++ b/src/parsing/abstract-parser.h
@@ -210,6 +210,7 @@ class AbstractParser
   friend bool v8::internal::parsing::ParseFunction(
       ParseInfo*, Handle<SharedFunctionInfo> shared_info, Isolate*,
       parsing::ReportErrorsAndStatisticsMode stats_mode);
+  friend class BinAstDeserializer;
 
   bool AllowsLazyParsingWithoutUnresolvedVariables() const {
     return !impl()->MaybeParsingArrowhead() &&

--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -901,7 +901,8 @@ BinAstDeserializer::DeserializeResult<ObjectLiteral*> BinAstDeserializer::Deseri
   auto literal_position = DeserializeInt32(serialized_binast, offset);
   offset = literal_position.new_offset;
 
-  ScopedPtrList<ObjectLiteral::Property> properties(parser_->pointer_buffer());
+  std::vector<void*> pointer_buffer;
+  ScopedPtrList<ObjectLiteral::Property> properties(&pointer_buffer);
 
   int number_of_boilerplate_properties = 0;  // add increments for this
 

--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -933,9 +933,10 @@ BinAstDeserializer::DeserializeResult<ObjectLiteral*> BinAstDeserializer::Deseri
     properties.Add(property);
   }
 
+  bool has_rest_property = false;
   ObjectLiteral* result = parser_->factory()->NewObjectLiteral(
       properties, number_of_boilerplate_properties, literal_position.value,
-      false);
+      has_rest_property);
   result->bit_field_ = bit_field;
   return {result, offset};
 }

--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -178,7 +178,10 @@ BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::DeserializeA
     auto result = DeserializeUnaryOperation(serialized_binast, bit_field.value, position.value, offset);
     return {result.value, result.new_offset};
   }
-  case AstNode::kObjectLiteral:
+  case AstNode::kObjectLiteral: {
+    auto result = DeserializeObjectLiteral(serialized_binast, bit_field.value, position.value, offset);
+    return {result.value, result.new_offset};
+  }
   case AstNode::kArrayLiteral:
   case AstNode::kNaryOperation:
   case AstNode::kTryCatchStatement:
@@ -887,6 +890,51 @@ BinAstDeserializer::DeserializeResult<UnaryOperation*> BinAstDeserializer::Deser
 
 BinAstDeserializer::DeserializeResult<ThisExpression*> BinAstDeserializer::DeserializeThisExpression(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
   ThisExpression* result = parser_->factory()->ThisExpression();
+  result->bit_field_ = bit_field;
+  return {result, offset};
+}
+
+BinAstDeserializer::DeserializeResult<ObjectLiteral*> BinAstDeserializer::DeserializeObjectLiteral(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
+  auto properties_length = DeserializeInt32(serialized_binast, offset);
+  offset = properties_length.new_offset;
+
+  auto literal_position = DeserializeInt32(serialized_binast, offset);
+  offset = literal_position.new_offset;
+
+  ScopedPtrList<ObjectLiteral::Property> properties(parser_->pointer_buffer());
+
+  int number_of_boilerplate_properties = 0;  // add increments for this
+
+  for (int i = 0; i < properties_length.value; i++) {
+    auto key = DeserializeAstNode(serialized_binast, offset);
+    offset = key.new_offset;
+
+    auto value = DeserializeAstNode(serialized_binast, offset);
+    offset = value.new_offset;
+
+    auto kind = DeserializeUint8(serialized_binast, offset);
+    offset = kind.new_offset;
+
+    auto is_computed_name = DeserializeUint8(serialized_binast, offset);
+    offset = is_computed_name.new_offset;
+
+    auto property = parser_->factory()->NewObjectLiteralProperty(
+        static_cast<Expression*>(key.value),
+        static_cast<Expression*>(value.value),
+        static_cast<ObjectLiteral::Property::Kind>(kind.value),
+        is_computed_name.value);
+
+    if (parser_->IsBoilerplateProperty(property) &&
+        !is_computed_name.value) {
+      number_of_boilerplate_properties++;
+    }
+
+    properties.Add(property);
+  }
+
+  ObjectLiteral* result = parser_->factory()->NewObjectLiteral(
+      properties, number_of_boilerplate_properties, literal_position.value,
+      false);
   result->bit_field_ = bit_field;
   return {result, offset};
 }

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -93,6 +93,7 @@ class BinAstDeserializer {
   DeserializeResult<CompoundAssignment*> DeserializeCompoundAssignment(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<UnaryOperation*> DeserializeUnaryOperation(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<ThisExpression*> DeserializeThisExpression(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
+  DeserializeResult<ObjectLiteral*> DeserializeObjectLiteral(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<std::nullptr_t> DeserializeNodeStub(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
 
   Isolate* isolate_;

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -859,6 +859,9 @@ inline void BinAstSerializeVisitor::VisitObjectLiteral(ObjectLiteral* object_lit
     SerializeUint8(property->kind());
 
     if (property->kind() == ObjectLiteral::Property::SPREAD) {
+      printf(
+          "BinAstSerializeVisitor encountered unhandled spread in object "
+          "literal, skipping function\n");
       encountered_unhandled_nodes_++;
     }
 

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -68,7 +68,7 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   virtual void VisitBinaryOperation(BinaryOperation* binary_op) override;
   virtual void VisitNaryOperation(NaryOperation* nary_op) override;
 
-  virtual void VisitObjectLiteral(ObjectLiteral* binary_op) override;
+  virtual void VisitObjectLiteral(ObjectLiteral* object_literal) override;
   virtual void VisitArrayLiteral(ArrayLiteral* array_literal) override;
   virtual void VisitCompoundAssignment(
       CompoundAssignment* compound_assignment) override;
@@ -847,7 +847,23 @@ inline void BinAstSerializeVisitor::VisitNaryOperation(NaryOperation* nary_op) {
 
 inline void BinAstSerializeVisitor::VisitObjectLiteral(ObjectLiteral* object_literal) {
   SerializeAstNodeHeader(object_literal);
-  ToDoBinAst(object_literal);
+
+  SerializeInt32(object_literal->properties()->length());
+  SerializeInt32(object_literal->position());
+
+  for (int i = 0; i < object_literal->properties()->length(); i++) {
+    auto property = object_literal->properties()->at(i);
+
+    VisitNode(property->key());
+    VisitNode(property->value());
+    SerializeUint8(property->kind());
+
+    if (property->kind() == ObjectLiteral::Property::SPREAD) {
+      encountered_unhandled_nodes_++;
+    }
+
+    SerializeUint8(property->is_computed_name());
+  }
 }
 
 inline void BinAstSerializeVisitor::VisitArrayLiteral(ArrayLiteral* array_literal) {


### PR DESCRIPTION
self-explanatory 

ObjectLiterals with spread properties are treated as unhandled