### PR TITLE
Fix a couple issues with temporary variable handling

### DIFF
--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -54,6 +54,9 @@ class BinAstDeserializer {
   DeserializeResult<const AstRawString*> DeserializeRawStringReference(uint8_t* bytes, int offset);
   DeserializeResult<AstConsString*> DeserializeConsString(uint8_t* bytes, int offset);
 
+  Variable* CreateLocalTemporaryVariable(Scope* scope, const AstRawString* name, int index, int initializer_position, uint32_t bit_field);
+  Variable* CreateLocalNonTemporaryVariable(Scope* scope, const AstRawString* name, int index, int initializer_position, uint32_t bit_field);
+
   DeserializeResult<Variable*> DeserializeLocalVariable(uint8_t* serialized_binast, int offset, Scope* scope);
   DeserializeResult<Variable*> DeserializeNonLocalVariable(uint8_t* serialized_binast, int offset, Scope* scope);
   DeserializeResult<Variable*> DeserializeVariableReference(uint8_t* serialized_binast, int offset, Scope* scope = nullptr);

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -397,6 +397,10 @@ inline void BinAstSerializeVisitor::SerializeVariable(Variable* variable) {
   SerializeRawStringReference(variable->raw_name());
 
   // local_if_not_shadowed_: TODO(binast): how to reference other local variables like this? index?
+  if (variable->has_local_if_not_shadowed()) {
+    printf("BinAstSerializeVisitor encountered unsupported variable with local_if_not_shadowed field set\n");
+    encountered_unhandled_nodes_++;
+  }
 
   SerializeInt32(variable->index());
   SerializeInt32(variable->initializer_position());
@@ -419,17 +423,19 @@ inline void BinAstSerializeVisitor::SerializeVariableReference(Variable* variabl
 
 inline void BinAstSerializeVisitor::SerializeScopeVariableMap(Scope* scope) {
   // Serialize locals first.
-  std::unordered_set<const AstRawString*> locals;
-  std::unordered_set<const AstRawString*> temporaries;
+  uint32_t total_local_vars = 0;
+  uint32_t total_temporaries = 0;
+  std::unordered_set<const AstRawString*> deduped_locals;
+  std::vector<const AstRawString*> temporaries;
   for (Variable* variable : scope->locals_) {
-    locals.insert(variable->raw_name());
+    total_local_vars++;
+    deduped_locals.insert(variable->raw_name());
+
     if (variable->mode() == VariableMode::kTemporary) {
-      temporaries.insert(variable->raw_name());
+      total_temporaries++;
     }
   }
 
-  DCHECK(locals.size() < UINT32_MAX);
-  uint32_t total_local_vars = static_cast<uint32_t>(locals.size());
   SerializeUint32(total_local_vars);
   for (Variable* variable : scope->locals_) {
     SerializeVariable(variable);
@@ -437,7 +443,7 @@ inline void BinAstSerializeVisitor::SerializeScopeVariableMap(Scope* scope) {
 
   // Now serialize any remaining variables we missed
   DCHECK(temporaries.size() < UINT32_MAX);
-  uint32_t total_non_temporary_locals = total_local_vars - static_cast<uint32_t>(temporaries.size());
+  uint32_t total_non_temporary_locals = total_local_vars - total_temporaries;
   DCHECK(static_cast<uint32_t>(scope->num_var()) >= total_non_temporary_locals);
   // Temporaries are only stored in locals_ (and not variables_), so don't include them in the non-local vars count.
   uint32_t total_nonlocal_vars = scope->num_var() - total_non_temporary_locals;
@@ -445,7 +451,7 @@ inline void BinAstSerializeVisitor::SerializeScopeVariableMap(Scope* scope) {
   SerializeUint32(total_nonlocal_vars);
   for (VariableMap::Entry* entry = scope->variables_.Start(); entry != nullptr; entry = scope->variables_.Next(entry)) {
     Variable* variable = reinterpret_cast<Variable*>(entry->value);
-    if (locals.count(variable->raw_name()) == 0) {
+    if (deduped_locals.count(variable->raw_name()) == 0) {
       SerializeVariable(variable);
       serialized_nonlocal_vars += 1;
     }

--- a/test/binast/test.js
+++ b/test/binast/test.js
@@ -17,6 +17,10 @@ function makeThing() {
 
 function explode2(a,b,c,d,e,f){"use strict";e.exports=a;function a(){return b;}}
 
+function defaultParam(interimText, opt_finalText = 'a') {
+  return opt_finalText;
+};
+
 var double = function(x) { return x * 2; }
 function triple(x) { return x * 3; }
 function deep() {
@@ -210,6 +214,7 @@ setTimeout(function testCallback2() {
   console.log(explode2(a, b, c, d, e));
   console.log(e);
   console.log(e.exports());
+  console.log(defaultParam());
 }, 5000);
 
 tickRunLoop();


### PR DESCRIPTION
We were using an unordered_set to store names for locals and temporaries (which are a subset of locals).
We would then use the total size of the sets to determine how many non-local variables to serialize.
This obviously wouldn't work in the presence of variable name collisions (as was the case in functions with
multiple "invisible" temporaries with empty names). We fixed this by explicitly counting how many locals
and temporaries there in addition to using unordered sets for fast lookups.

There was another issue on the deserialization side in that we were adding the temporary locals to the
set of scope variables (rather than just the scope's locals), which was causing us to generate incorrect bytecode.
We fixed this in the deserializer by distinguishing between temporary and non-temporary locals when
deserializing the scope's variable map.