### PR TITLE
Add handling for UncompiledDataWithInnerBinAstParseData object descri…

### DIFF
--- a/src/objects/objects-body-descriptors-inl.h
+++ b/src/objects/objects-body-descriptors-inl.h
@@ -1083,6 +1083,9 @@ ReturnType BodyDescriptorApply(InstanceType type, T1 p1, T2 p2, T3 p3, T4 p4) {
     case UNCOMPILED_DATA_WITH_BIN_AST_PARSE_DATA_TYPE:
       return Op::template apply<UncompiledDataWithBinAstParseData::BodyDescriptor>(
           p1, p2, p3, p4);
+    case UNCOMPILED_DATA_WITH_INNER_BIN_AST_PARSE_DATA_TYPE:
+      return Op::template apply<UncompiledDataWithInnerBinAstParseData::BodyDescriptor>(
+          p1, p2, p3, p4);
     case BIN_AST_PARSE_DATA_TYPE:
       return Op::template apply<BinAstParseData::BodyDescriptor>(p1, p2, p3, p4);
     case HEAP_NUMBER_TYPE:


### PR DESCRIPTION
…ptor

This was causing an assert periodically at runtime due to an unhandled switch condition.