### PR TITLE
Reserve std::vector capacity and other minor deserialization perf imp…

### DIFF
--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -61,189 +61,11 @@ AstNode* BinAstDeserializer::DeserializeAst(
   return result.value;
 }
 
-BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::DeserializeAstNode(uint8_t* serialized_binast, int offset, bool is_toplevel) {
-  auto bit_field = DeserializeUint32(serialized_binast, offset);
-  offset = bit_field.new_offset;
-
-  auto position = DeserializeInt32(serialized_binast, offset);
-  offset = position.new_offset;
-
-  AstNode::NodeType nodeType = AstNode::NodeTypeField::decode(bit_field.value);
-  switch (nodeType) {
-  case AstNode::kFunctionLiteral: {
-    BinAstDeserializer::DeserializeResult<uint32_t> start_offset =
-        DeserializeUint32(serialized_binast, offset);
-    offset = start_offset.new_offset;
-
-    BinAstDeserializer::DeserializeResult<uint32_t> length =
-        DeserializeUint32(serialized_binast, offset);
-    offset = length.new_offset;
-
-    auto result = DeserializeFunctionLiteral(serialized_binast, bit_field.value,
-                                             position.value, offset);
-
-    if (!is_toplevel) {
-      Handle<UncompiledDataWithInnerBinAstParseData> data =
-          isolate_->factory()->NewUncompiledDataWithInnerBinAstParseData(
-              result.value->GetInferredName(isolate_),
-              result.value->start_position(), result.value->end_position(),
-              parse_data_, start_offset.value, length.value);
-
-      result.value->set_uncompiled_data_with_inner_bin_ast_parse_data(data);
-    }
-
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kReturnStatement: {
-    auto result = DeserializeReturnStatement(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kBinaryOperation: {
-    auto result = DeserializeBinaryOperation(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kProperty: {
-    auto result = DeserializeProperty(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kExpressionStatement: {
-    auto result = DeserializeExpressionStatement(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kVariableProxyExpression: {
-    auto result = DeserializeVariableProxyExpression(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kLiteral: {
-    auto result = DeserializeLiteral(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kCall: {
-    auto result = DeserializeCall(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kCallNew: {
-    auto result = DeserializeCallNew(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kIfStatement: {
-    auto result = DeserializeIfStatement(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kBlock: {
-    auto result = DeserializeBlock(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kAssignment: {
-    auto result = DeserializeAssignment(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kCompareOperation: {
-    auto result = DeserializeCompareOperation(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kEmptyStatement: {
-    auto result = DeserializeEmptyStatement(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kForStatement: {
-    auto result = DeserializeForStatement(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kForInStatement: {
-    auto result = DeserializeForInStatement(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kCountOperation: {
-    auto result = DeserializeCountOperation(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kCompoundAssignment: {
-    auto result = DeserializeCompoundAssignment(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kWhileStatement: {
-    auto result = DeserializeWhileStatement(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kDoWhileStatement: {
-    auto result = DeserializeDoWhileStatement(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kThisExpression: {
-    auto result = DeserializeThisExpression(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kUnaryOperation: {
-    auto result = DeserializeUnaryOperation(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kObjectLiteral: {
-    auto result = DeserializeObjectLiteral(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kArrayLiteral: {
-    auto result = DeserializeArrayLiteral(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kNaryOperation: {
-    auto result = DeserializeNaryOperation(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kConditional: {
-    auto result = DeserializeConditional(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kTryCatchStatement: {
-    auto result = DeserializeTryCatchStatement(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kRegExpLiteral: {
-    auto result = DeserializeRegExpLiteral(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kSwitchStatement: {
-    auto result = DeserializeSwitchStatement(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kThrow: {
-    auto result = DeserializeThrow(serialized_binast, bit_field.value, position.value, offset);
-    return {result.value, result.new_offset};
-  }
-  case AstNode::kForOfStatement:
-  case AstNode::kSloppyBlockFunctionStatement:
-  case AstNode::kContinueStatement:
-  case AstNode::kBreakStatement:
-  case AstNode::kTryFinallyStatement:
-  case AstNode::kDebuggerStatement:
-  case AstNode::kInitializeClassMembersStatement:
-  case AstNode::kAwait:
-  case AstNode::kCallRuntime:
-  case AstNode::kClassLiteral:
-  case AstNode::kEmptyParentheses:
-  case AstNode::kGetTemplateObject:
-  case AstNode::kImportCallExpression:
-  case AstNode::kNativeFunctionLiteral:
-  case AstNode::kOptionalChain:
-  case AstNode::kSpread:
-  case AstNode::kSuperCallReference:
-  case AstNode::kSuperPropertyReference:
-  case AstNode::kTemplateLiteral:
-  case AstNode::kYield:
-  case AstNode::kYieldStar:
-  case AstNode::kWithStatement:
-  case AstNode::kFailureExpression: {
-    // We should never get here because the serializer should give up if it encounters these node types.
-    AstNode temp(0, nodeType);
-    printf("Got unhandled node type: %s\n", temp.node_type_name());
-    UNREACHABLE();
-  }
-  }
-}
-
 BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::DeserializeScopeVariableMap(uint8_t* serialized_binast, int offset, Scope* scope) {
   auto total_local_variables = DeserializeUint32(serialized_binast, offset);
   offset = total_local_variables.new_offset;
+
+  variables_by_id_.reserve(total_local_variables.value);
 
   for (uint32_t i = 0; i < total_local_variables.value; ++i) {
     auto start_offset = offset;
@@ -255,6 +77,8 @@ BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::Deseri
 
   auto total_nonlocal_variables = DeserializeUint32(serialized_binast, offset);
   offset = total_nonlocal_variables.new_offset;
+
+  variables_by_id_.reserve(total_local_variables.value + total_nonlocal_variables.value);
 
   for (uint32_t i = 0; i < total_nonlocal_variables.value; ++i) {
     auto start_offset = offset;
@@ -557,11 +381,13 @@ BinAstDeserializer::DeserializeResult<FunctionLiteral*> BinAstDeserializer::Dese
   FunctionLiteral::EagerCompileHint eager_compile_hint = scope.value->ShouldEagerCompile() ? FunctionLiteral::kShouldEagerCompile : FunctionLiteral::kShouldLazyCompile;
   bool has_braces = FunctionLiteral::HasBracesField::decode(bit_field);
 
-  std::vector<void*> pointer_buffer;
-  ScopedPtrList<Statement> body(&pointer_buffer);
+
   auto num_statements = DeserializeInt32(serialized_binast, offset);
   offset = num_statements.new_offset;
 
+  std::vector<void*> pointer_buffer;
+  pointer_buffer.reserve(num_statements.value);
+  ScopedPtrList<Statement> body(&pointer_buffer);
   {
     Parser::FunctionState function_state(&parser_->function_state_, &parser_->scope_, scope.value);
 
@@ -583,338 +409,6 @@ BinAstDeserializer::DeserializeResult<FunctionLiteral*> BinAstDeserializer::Dese
   result->suspend_count_ = suspend_count.value;
   result->bit_field_ = bit_field;
 
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<ReturnStatement*> BinAstDeserializer::DeserializeReturnStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  auto end_position = DeserializeInt32(serialized_binast, offset);
-  offset = end_position.new_offset;
-
-  auto expression = DeserializeAstNode(serialized_binast, offset);
-  offset = expression.new_offset;
-
-  ReturnStatement* result = parser_->factory()->NewReturnStatement(static_cast<Expression*>(expression.value), position, end_position.value);
-  result->bit_field_ = bit_field;
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<BinaryOperation*> BinAstDeserializer::DeserializeBinaryOperation(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  auto left = DeserializeAstNode(serialized_binast, offset);
-  offset = left.new_offset;
-
-  auto right = DeserializeAstNode(serialized_binast, offset);
-  offset = right.new_offset;
-
-  Token::Value op = BinaryOperation::OperatorField::decode(bit_field);
-
-  BinaryOperation* result = parser_->factory()->NewBinaryOperation(op, static_cast<Expression*>(left.value), static_cast<Expression*>(right.value), position);
-  result->bit_field_ = bit_field;
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<Property*> BinAstDeserializer::DeserializeProperty(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  auto obj = DeserializeAstNode(serialized_binast, offset);
-  offset = obj.new_offset;
-
-  auto key = DeserializeAstNode(serialized_binast, offset);
-  offset = key.new_offset;
-
-  Property* result = parser_->factory()->NewProperty(static_cast<Expression*>(obj.value), static_cast<Expression*>(key.value), position);
-  result->bit_field_ = bit_field;
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<ExpressionStatement*> BinAstDeserializer::DeserializeExpressionStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  auto expression = DeserializeAstNode(serialized_binast, offset);
-  offset = expression.new_offset;
-
-  ExpressionStatement* result = parser_->factory()->NewExpressionStatement(static_cast<Expression*>(expression.value), offset);
-  result->bit_field_ = bit_field;
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<VariableProxy*> BinAstDeserializer::DeserializeVariableProxy(uint8_t* serialized_binast, int offset) {
-  auto position = DeserializeInt32(serialized_binast, offset);
-  offset = position.new_offset;
-
-  auto bit_field = DeserializeUint32(serialized_binast, offset);
-  offset = bit_field.new_offset;
-
-  bool is_resolved = VariableProxy::IsResolvedField::decode(bit_field.value);
-
-  VariableProxy* result;
-  if (is_resolved) {
-    // The resolved Variable should either be a reference (i.e. currently visible in scope) or should be a 
-    // NonScope Variable definition (i.e. it's a Variable that is outside the current Scope boundaries, 
-    // e.g. inside an eval).
-    auto variable = DeserializeNonScopeVariableOrReference(serialized_binast, offset);
-    offset = variable.new_offset;
-    result = parser_->factory()->NewVariableProxy(variable.value, position.value);
-  } else {
-    auto raw_name = DeserializeRawStringReference(serialized_binast, offset);
-    offset = raw_name.new_offset;
-    // We use NORMAL_VARIABLE as a placeholder here.
-    result = parser_->factory()->NewVariableProxy(raw_name.value, VariableKind::NORMAL_VARIABLE, position.value);
-
-    parser_->scope()->AddUnresolved(result);
-  }
-  result->bit_field_ = bit_field.value;
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<VariableProxyExpression*> BinAstDeserializer::DeserializeVariableProxyExpression(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  auto variable_proxy = DeserializeVariableProxy(serialized_binast, offset);
-  offset = variable_proxy.new_offset;
-
-  VariableProxyExpression* result = parser_->factory()->NewVariableProxyExpression(variable_proxy.value);
-  result->bit_field_ = bit_field;
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<Call*> BinAstDeserializer::DeserializeCall(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  auto expression = DeserializeAstNode(serialized_binast, offset);
-  offset = expression.new_offset;
-
-  auto params_count = DeserializeInt32(serialized_binast, offset);
-  offset = params_count.new_offset;
-
-  std::vector<void*> pointer_buffer;
-  ScopedPtrList<Expression> params(&pointer_buffer);
-  for (int i = 0; i < params_count.value; ++i) {
-    auto param = DeserializeAstNode(serialized_binast, offset);
-    offset = param.new_offset;
-    params.Add(static_cast<Expression*>(param.value));
-  }
-
-  Call* result = parser_->factory()->NewCall(static_cast<Expression*>(expression.value), params, position);
-  result->bit_field_ = bit_field;
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<CallNew*> BinAstDeserializer::DeserializeCallNew(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  auto expression = DeserializeAstNode(serialized_binast, offset);
-  offset = expression.new_offset;
-
-  auto params_count = DeserializeInt32(serialized_binast, offset);
-  offset = params_count.new_offset;
-
-  std::vector<void*> pointer_buffer;
-  ScopedPtrList<Expression> params(&pointer_buffer);
-  for (int i = 0; i < params_count.value; ++i) {
-    auto param = DeserializeAstNode(serialized_binast, offset);
-    offset = param.new_offset;
-    params.Add(static_cast<Expression*>(param.value));
-  }
-
-  CallNew* result = parser_->factory()->NewCallNew(static_cast<Expression*>(expression.value), params, position);
-  result->bit_field_ = bit_field;
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<IfStatement*> BinAstDeserializer::DeserializeIfStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  auto condition = DeserializeAstNode(serialized_binast, offset);
-  offset = condition.new_offset;
-
-  auto then_statement = DeserializeAstNode(serialized_binast, offset);
-  offset = then_statement.new_offset;
-
-  auto else_statement = DeserializeAstNode(serialized_binast, offset);
-  offset = else_statement.new_offset;
-
-  IfStatement* result = parser_->factory()->NewIfStatement(static_cast<Expression*>(condition.value), static_cast<Statement*>(then_statement.value), static_cast<Statement*>(else_statement.value), position);
-  result->bit_field_ = bit_field;
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<Block*> BinAstDeserializer::DeserializeBlock(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  auto has_scope = DeserializeUint8(serialized_binast, offset);
-  offset = has_scope.new_offset;
-
-  Scope* scope = nullptr;
-  if (has_scope.value) {
-    auto scope_result = DeserializeScope(serialized_binast, offset);
-    offset = scope_result.new_offset;
-    scope = scope_result.value;
-  }
-
-  auto statement_count = DeserializeInt32(serialized_binast, offset);
-  offset = statement_count.new_offset;
-
-  std::vector<void*> pointer_buffer;
-  ScopedPtrList<Statement> statements(&pointer_buffer);
-  if (scope != nullptr) {
-    Parser::BlockState block_state(&parser_->scope_, scope);
-    for (int i = 0; i < statement_count.value; ++i) {
-      auto statement = DeserializeAstNode(serialized_binast, offset);
-      offset = statement.new_offset;
-      statements.Add(static_cast<Statement*>(statement.value));
-    }
-  } else {
-    for (int i = 0; i < statement_count.value; ++i) {
-      auto statement = DeserializeAstNode(serialized_binast, offset);
-      offset = statement.new_offset;
-      statements.Add(static_cast<Statement*>(statement.value));
-    }
-  }
-
-  bool ignore_completion_value = false; // Just a filler value.
-  Block* result = parser_->factory()->NewBlock(ignore_completion_value, statements);
-  result->bit_field_ = bit_field;
-  result->set_scope(scope);
-
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<Assignment*> BinAstDeserializer::DeserializeAssignment(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  auto target = DeserializeAstNode(serialized_binast, offset);
-  offset = target.new_offset;
-
-  auto value = DeserializeAstNode(serialized_binast, offset);
-  offset = value.new_offset;
-
-  Token::Value op = Assignment::TokenField::decode(bit_field);
-  Assignment* result = parser_->factory()->NewAssignment(op, static_cast<Expression*>(target.value), static_cast<Expression*>(value.value), position);
-  result->bit_field_ = bit_field;
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<CompareOperation*> BinAstDeserializer::DeserializeCompareOperation(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  auto left = DeserializeAstNode(serialized_binast, offset);
-  offset = left.new_offset;
-
-  auto right = DeserializeAstNode(serialized_binast, offset);
-  offset = right.new_offset;
-
-  Token::Value op = CompareOperation::OperatorField::decode(bit_field);
-  CompareOperation* result = parser_->factory()->NewCompareOperation(op, static_cast<Expression*>(left.value), static_cast<Expression*>(right.value), position);
-  result->bit_field_ = bit_field;
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<EmptyStatement*> BinAstDeserializer::DeserializeEmptyStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  EmptyStatement* result = parser_->factory()->EmptyStatement();
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::DeserializeMaybeAstNode(uint8_t* serialized_binast, int offset) {
-  auto has_node = DeserializeUint8(serialized_binast, offset);
-  offset = has_node.new_offset;
-
-  if (has_node.value) {
-    auto node = DeserializeAstNode(serialized_binast, offset);
-    offset = node.new_offset;
-    return {node.value, offset};
-  }
-  return {nullptr, offset};
-}
-
-BinAstDeserializer::DeserializeResult<ForStatement*> BinAstDeserializer::DeserializeForStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  auto init_node = DeserializeMaybeAstNode(serialized_binast, offset);
-  offset = init_node.new_offset;
-
-  auto cond_node = DeserializeMaybeAstNode(serialized_binast, offset);
-  offset = cond_node.new_offset;
-
-  auto next_node = DeserializeMaybeAstNode(serialized_binast, offset);
-  offset = next_node.new_offset;
-
-  auto body = DeserializeAstNode(serialized_binast, offset);
-  offset = body.new_offset;
-
-  ForStatement* result = parser_->factory()->NewForStatement(position);
-  result->Initialize(
-    static_cast<Statement*>(init_node.value),
-    static_cast<Expression*>(cond_node.value),
-    static_cast<Statement*>(next_node.value),
-    static_cast<Statement*>(body.value));
-  result->bit_field_ = bit_field;
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<ForInStatement*> BinAstDeserializer::DeserializeForInStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  auto each = DeserializeAstNode(serialized_binast, offset);
-  offset = each.new_offset;
-
-  auto subject = DeserializeAstNode(serialized_binast, offset);
-  offset = subject.new_offset;
-
-  auto body = DeserializeAstNode(serialized_binast, offset);
-  offset = body.new_offset;
-
-  ForEachStatement* result = parser_->factory()->NewForEachStatement(ForEachStatement::ENUMERATE, position);
-  result->Initialize(static_cast<Expression*>(each.value), static_cast<Expression*>(subject.value), static_cast<Statement*>(body.value));
-  result->bit_field_ = bit_field;
-  DCHECK(result->IsForInStatement());
-  return {static_cast<ForInStatement*>(result), offset};
-}
-
-BinAstDeserializer::DeserializeResult<WhileStatement*> BinAstDeserializer::DeserializeWhileStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  auto cond = DeserializeAstNode(serialized_binast, offset);
-  offset = cond.new_offset;
-
-  auto body = DeserializeAstNode(serialized_binast, offset);
-  offset = body.new_offset;
-
-  WhileStatement* result = parser_->factory()->NewWhileStatement(position);
-  result->Initialize(static_cast<Expression*>(cond.value), static_cast<Statement*>(body.value));
-  result->bit_field_ = bit_field;
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<DoWhileStatement*> BinAstDeserializer::DeserializeDoWhileStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  auto cond = DeserializeAstNode(serialized_binast, offset);
-  offset = cond.new_offset;
-
-  auto body = DeserializeAstNode(serialized_binast, offset);
-  offset = body.new_offset;
-
-  DoWhileStatement* result = parser_->factory()->NewDoWhileStatement(position);
-  result->Initialize(static_cast<Expression*>(cond.value), static_cast<Statement*>(body.value));
-  result->bit_field_ = bit_field;
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<CountOperation*> BinAstDeserializer::DeserializeCountOperation(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  auto expression = DeserializeAstNode(serialized_binast, offset);
-  offset = expression.new_offset;
-
-  Token::Value op = CountOperation::TokenField::decode(bit_field);
-  bool is_prefix = CountOperation::IsPrefixField::decode(bit_field);
-
-  CountOperation* result = parser_->factory()->NewCountOperation(op, is_prefix, static_cast<Expression*>(expression.value), position);
-  result->bit_field_ = bit_field;
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<CompoundAssignment*> BinAstDeserializer::DeserializeCompoundAssignment(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  auto target = DeserializeAstNode(serialized_binast, offset);
-  offset = target.new_offset;
-
-  auto value = DeserializeAstNode(serialized_binast, offset);
-  offset = value.new_offset;
-
-  auto binary_operation = DeserializeAstNode(serialized_binast, offset);
-  offset = binary_operation.new_offset;
-
-  Token::Value op = Assignment::TokenField::decode(bit_field);
-  Assignment* result = parser_->factory()->NewAssignment(op, static_cast<Expression*>(target.value), static_cast<Expression*>(value.value), position);
-  result->bit_field_ = bit_field;
-  return {result->AsCompoundAssignment(), offset};
-}
-
-BinAstDeserializer::DeserializeResult<UnaryOperation*> BinAstDeserializer::DeserializeUnaryOperation(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  auto expression = DeserializeAstNode(serialized_binast, offset);
-  offset = expression.new_offset;
-
-  Token::Value op = UnaryOperation::OperatorField::decode(bit_field);
-  UnaryOperation* result = parser_->factory()->NewUnaryOperation(op, static_cast<Expression*>(expression.value), position);
-  result->bit_field_ = bit_field;
-  return {result, offset};
-}
-
-BinAstDeserializer::DeserializeResult<ThisExpression*> BinAstDeserializer::DeserializeThisExpression(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
-  ThisExpression* result = parser_->factory()->ThisExpression();
-  result->bit_field_ = bit_field;
   return {result, offset};
 }
 
@@ -975,6 +469,7 @@ BinAstDeserializer::DeserializeArrayLiteral(uint8_t* serialized_binast,
   DCHECK(first_spread_index.value == -1);
 
   std::vector<void*> pointer_buffer;
+  pointer_buffer.reserve(array_length.value);
   ScopedPtrList<Expression> values(&pointer_buffer);
 
   for (int i = 0; i < array_length.value; i++) {
@@ -1109,6 +604,7 @@ BinAstDeserializer::DeserializeSwitchStatement(uint8_t* serialized_binast,
     offset = statements_length.new_offset;
 
     std::vector<void*> pointer_buffer;
+    pointer_buffer.reserve(statements_length.value);
     ScopedPtrList<Statement> statements(&pointer_buffer);
 
     for (int i = 0; i < statements_length.value; i++) {


### PR DESCRIPTION
…rovements

Profiling indicated we were spending a significant chunk of time performing dynamic
memory allocation and deallocation during deserialization due to std::vector resizing.
This diff changes things so that we now pre-reserve the underlying capacity for these
vectors since we already know how long they'll be.

This diff also moves a handful of small deserialization functions to be inlineable as
well as combining a couple 32-bit reads into a single 64-bit read.

These changes improved performance such that a somewhat unscientific measurement of
deserialization vs parsing speed shows that deserialization tends to be faster than
parsing for functions greater than 500 bytes, and at 3000 bytes deserialization is
now roughly 25% faster than parsing.