### PR TITLE
Enable inner preparse data and implement more micro optimizations

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -2480,6 +2480,10 @@ class FunctionLiteral final : public Expression {
     return uncompiled_data_with_inner_bin_ast_parse_data_;
   }
 
+  bool has_uncompiled_data_with_inner_bin_ast_parse_data() const {
+    return !uncompiled_data_with_inner_bin_ast_parse_data_.is_null();
+  }
+
   void set_uncompiled_data_with_inner_bin_ast_parse_data(
       Handle<UncompiledDataWithInnerBinAstParseData> data) {
     uncompiled_data_with_inner_bin_ast_parse_data_ = data;
@@ -2556,6 +2560,7 @@ class FunctionLiteral final : public Expression {
   ProducedPreparseData* produced_preparse_data_;
   ProducedBinAstParseData* produced_binast_parse_data_;
 
+  // TODO(binast): Change this to raw zone pointer to more closely imitate the other preparse behavior.
   Handle<UncompiledDataWithInnerBinAstParseData>
       uncompiled_data_with_inner_bin_ast_parse_data_;
 };

--- a/src/objects/objects.cc
+++ b/src/objects/objects.cc
@@ -5466,6 +5466,8 @@ void SharedFunctionInfo::InitFromFunctionLiteral(
     data = isolate->factory()->NewUncompiledDataWithPreparseData(
         lit->GetInferredName(isolate), lit->start_position(),
         lit->end_position(), preparse_data);
+  } else if (lit->has_uncompiled_data_with_inner_bin_ast_parse_data()) {
+    data = lit->uncompiled_data_with_inner_bin_ast_parse_data();
   } else {
     data = isolate->factory()->NewUncompiledDataWithoutPreparseData(
         lit->GetInferredName(isolate), lit->start_position(),

--- a/src/parsing/abstract-parser.h
+++ b/src/parsing/abstract-parser.h
@@ -2045,12 +2045,14 @@ void AbstractParser<Impl>::ParseFunction(
       AstNode* ast_node = deserializer.DeserializeAst(offset, length);
       literal = ast_node->AsFunctionLiteral();
       DCHECK(literal != nullptr);
-    }
-    auto elapsed = std::chrono::high_resolution_clock::now() - start;
-    deserialize_microseconds =
+      result = literal;
+
+      auto elapsed = std::chrono::high_resolution_clock::now() - start;
+      deserialize_microseconds =
         std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
-    // TODO(binast): Store the literal on the ParseInfo
-    // result = literal;
+      int function_length = result->end_position() - result->start_position();
+      printf("PREPARSE++: Deserialize time for %sfunction (%d bytes) in %lld us", is_inner ? "inner " : "", function_length, deserialize_microseconds);
+    }
   }
 
   if (V8_UNLIKELY(result == nullptr && shared_info->private_name_lookup_skips_outer_class() &&
@@ -2069,11 +2071,8 @@ void AbstractParser<Impl>::ParseFunction(
     auto elapsed = std::chrono::high_resolution_clock::now() - start;
     long long parse_microseconds =
         std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
-    if (deserialize_microseconds > 0) {
-      double percent_change = (double)(deserialize_microseconds - parse_microseconds) / (double)parse_microseconds * 100.0;
-      int function_length = result->end_position() - result->start_position();
-      printf("Parse time: %lld vs deserialize time: %lld (%lf%% change) for %d bytes\n", parse_microseconds, deserialize_microseconds, percent_change, function_length);
-    }
+    int function_length = result->end_position() - result->start_position();
+    printf("PREPARSE++: Parse time: %lld us for %d bytes\n", parse_microseconds, function_length);
   }
   MaybeResetCharacterStream(info, result);
   MaybeProcessSourceRanges(info, result, impl()->stack_limit_);

--- a/src/parsing/binast-deserializer-inl.h
+++ b/src/parsing/binast-deserializer-inl.h
@@ -144,22 +144,18 @@ inline BinAstDeserializer::DeserializeResult<const AstRawString*> BinAstDeserial
   auto length = DeserializeUint32(serialized_ast, offset);
   offset = length.new_offset;
 
-  std::vector<uint8_t> raw_data;
-  raw_data.reserve(length.value);
-  for (uint32_t i = 0; i < length.value; ++i) {
-    auto next_byte = DeserializeUint8(serialized_ast, offset);
-    offset = next_byte.new_offset;
-    raw_data.push_back(next_byte.value);
-  }
+  std::unique_ptr<uint8_t[]> raw_data(new uint8_t[length.value]);
+  memcpy(raw_data.get(), &serialized_ast[offset], length.value);
+  offset += sizeof(uint8_t) * length.value;
   const AstRawString* s = nullptr;
-  if (raw_data.size() > 0) {
-    Vector<const byte> literal_bytes(&raw_data[0], raw_data.size());
+  if (length.value > 0) {
+    Vector<const byte> literal_bytes(raw_data.get(), length.value);
     s = parser_->ast_value_factory()->GetString(hash_field.value, is_one_byte.value, literal_bytes);
   } else {
     Vector<const byte> literal_bytes;
     s = parser_->ast_value_factory()->GetString(hash_field.value, is_one_byte.value, literal_bytes);
   }
-  string_table_.insert({string_table_.size() + 1, s});
+  string_table_vec_.push_back(s);
   return {s, offset};
 }
 
@@ -167,7 +163,7 @@ inline BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer:
   auto num_non_constant_entries = DeserializeUint32(serialized_ast, offset);
   offset = num_non_constant_entries.new_offset;
 
-  string_table_.reserve(num_non_constant_entries.value);
+  string_table_vec_.reserve(num_non_constant_entries.value + parser_->ast_value_factory()->string_constants_->string_table()->occupancy());
 
   for (uint32_t i = 0; i < num_non_constant_entries.value; ++i) {
     auto string = DeserializeRawString(serialized_ast, offset);
@@ -176,7 +172,7 @@ inline BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer:
 
   for (base::HashMap::Entry* entry = parser_->ast_value_factory()->string_constants_->string_table()->Start(); entry != nullptr; entry = parser_->ast_value_factory()->string_constants_->string_table()->Next(entry)) {
     const AstRawString* s = reinterpret_cast<const AstRawString*>(entry->key);
-    string_table_.insert({string_table_.size() + 1, s});
+    string_table_vec_.push_back(s);
   }
 
   return {nullptr, offset};
@@ -188,10 +184,9 @@ inline BinAstDeserializer::DeserializeResult<const AstRawString*> BinAstDeserial
   if (string_table_index.value == 0) {
     return {nullptr, offset};
   }
-  auto lookup_result = string_table_.find(string_table_index.value);
-  DCHECK(lookup_result != string_table_.end());
-  const AstRawString* result = lookup_result->second;
-  DCHECK(result != nullptr);
+
+  DCHECK(string_table_index.value > 0 && string_table_index.value <= string_table_vec_.size());
+  const AstRawString* result = string_table_vec_[string_table_index.value - 1];
   return {result, offset};
 }
 
@@ -436,6 +431,7 @@ inline BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::Deser
     auto result = DeserializeFunctionLiteral(serialized_binast, bit_field, position, offset);
 
     if (!is_toplevel) {
+      printf("PREPARSE++: Storing inner binast parse data on function literal\n");
       Handle<UncompiledDataWithInnerBinAstParseData> data =
           isolate_->factory()->NewUncompiledDataWithInnerBinAstParseData(
               result.value->GetInferredName(isolate_),

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -36,6 +36,13 @@ class BinAstDeserializer {
   Zone* zone();
   static bool UseCompression() { return false; }
 
+  AstNode* DeserializeCompressedAst(base::Optional<uint32_t> start_offset,
+                        base::Optional<uint32_t> length);
+  AstNode* DeserializeUncompressedAst(base::Optional<uint32_t> start_offset,
+                                      base::Optional<uint32_t> length,
+                                      uint8_t* uncompressed_ast,
+                                      size_t uncompressed_size);
+
   DeserializeResult<AstNode*> DeserializeMaybeAstNode(uint8_t* serialized_binast, int offset);
 
   DeserializeResult<uint64_t> DeserializeUint64(uint8_t* bytes, int offset);
@@ -109,7 +116,7 @@ class BinAstDeserializer {
   Isolate* isolate_;
   Parser* parser_;
   Handle<ByteArray> parse_data_;
-  std::unordered_map<uint32_t, const AstRawString*> string_table_;
+  std::vector<const AstRawString*> string_table_vec_;
   std::unordered_map<uint32_t, Variable*> variables_by_id_;
 };
 


### PR DESCRIPTION
We were creating the inner preparse data but weren't passing it along to the SharedFunctionInfos
when generating bytecode. As of this diff we have started deserializing some inner functions,
although they appear to be quite slow.

This diff also adds a few micro optimizations meant to help small functions (which inner functions
are often small leaf functions) by reducing the fixed cost overhead of deserialization. These
include:

* getting rid of the copy out of the ByteArray at the beginning of deserialization for the
uncompressed path
* using std::vector for the string table during deserialization instead of std::unordered_map to
  speed up insertion and lookup
* using memcpy for copying the serialized raw string data instead of reading one char at a time
  and pushing into a std::vector