### PR TITLE
Add support for BreakStatement & ContinueStatement

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -749,6 +749,7 @@ class ContinueStatement final : public JumpStatement {
 
  private:
   friend class AstNodeFactory;
+  friend class BinAstDeserializer;
 
   ContinueStatement(IterationStatement* target, int pos)
       : JumpStatement(pos, kContinueStatement), target_(target) {}
@@ -763,6 +764,7 @@ class BreakStatement final : public JumpStatement {
 
  private:
   friend class AstNodeFactory;
+  friend class BinAstDeserializer;
 
   BreakStatement(BreakableStatement* target, int pos)
       : JumpStatement(pos, kBreakStatement), target_(target) {}

--- a/src/parsing/abstract-parser.h
+++ b/src/parsing/abstract-parser.h
@@ -2006,16 +2006,17 @@ void AbstractParser<Impl>::ParseFunction(
 
   long long deserialize_microseconds = 0;
   FunctionLiteral* result = nullptr;
+  bool is_inner_binast = false;
   if (V8_UNLIKELY(shared_info->HasUncompiledDataWithBinAstParseData() ||
                   shared_info->HasUncompiledDataWithInnerBinAstParseData())) {
     RuntimeCallTimerScope runtime_timer(
         impl()->runtime_call_stats_, RuntimeCallCounterId::kDeserializeBinAst);
     auto start = std::chrono::high_resolution_clock::now();
-    bool is_inner = shared_info->HasUncompiledDataWithInnerBinAstParseData();
+    is_inner_binast = shared_info->HasUncompiledDataWithInnerBinAstParseData();
     Handle<ByteArray> binast_parse_data;
     base::Optional<uint32_t> offset;
     base::Optional<uint32_t> length;
-    if (is_inner) {
+    if (is_inner_binast) {
       Handle<UncompiledDataWithInnerBinAstParseData> uncompiled_data =
           handle(shared_info->uncompiled_data_with_inner_bin_ast_parse_data(),
                 isolate);
@@ -2051,7 +2052,7 @@ void AbstractParser<Impl>::ParseFunction(
       deserialize_microseconds =
         std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
       int function_length = result->end_position() - result->start_position();
-      printf("PREPARSE++: Deserialize time for %sfunction (%d bytes) in %lld us", is_inner ? "inner " : "", function_length, deserialize_microseconds);
+      printf("PREPARSE++: Deserialize time for %sfunction (%d bytes) in %lld us", is_inner_binast ? "inner " : "", function_length, deserialize_microseconds);
     }
   }
 

--- a/src/parsing/binast-deserializer-inl.h
+++ b/src/parsing/binast-deserializer-inl.h
@@ -408,6 +408,8 @@ inline BinAstDeserializer::DeserializeResult<Variable*> BinAstDeserializer::Dese
 }
 
 inline BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::DeserializeAstNode(uint8_t* serialized_binast, int offset, bool is_toplevel) {
+  auto original_offset = offset;
+
   auto bit_field_and_position = DeserializeUint64(serialized_binast, offset);
   offset = bit_field_and_position.new_offset;
 
@@ -418,6 +420,7 @@ inline BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::Deser
   int32_t position = bit_field_and_position_convertor.fields.second;
 
   AstNode::NodeType nodeType = AstNode::NodeTypeField::decode(bit_field);
+
   switch (nodeType) {
   case AstNode::kFunctionLiteral: {
     BinAstDeserializer::DeserializeResult<uint32_t> start_offset =
@@ -431,7 +434,6 @@ inline BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::Deser
     auto result = DeserializeFunctionLiteral(serialized_binast, bit_field, position, offset);
 
     if (!is_toplevel) {
-      printf("PREPARSE++: Storing inner binast parse data on function literal\n");
       Handle<UncompiledDataWithInnerBinAstParseData> data =
           isolate_->factory()->NewUncompiledDataWithInnerBinAstParseData(
               result.value->GetInferredName(isolate_),
@@ -481,6 +483,7 @@ inline BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::Deser
   }
   case AstNode::kBlock: {
     auto result = DeserializeBlock(serialized_binast, bit_field, position, offset);
+    RecordBreakableStatement(original_offset, result.value);
     return {result.value, result.new_offset};
   }
   case AstNode::kAssignment: {
@@ -497,10 +500,12 @@ inline BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::Deser
   }
   case AstNode::kForStatement: {
     auto result = DeserializeForStatement(serialized_binast, bit_field, position, offset);
+    RecordBreakableStatement(original_offset, result.value);
     return {result.value, result.new_offset};
   }
   case AstNode::kForInStatement: {
     auto result = DeserializeForInStatement(serialized_binast, bit_field, position, offset);
+    RecordBreakableStatement(original_offset, result.value);
     return {result.value, result.new_offset};
   }
   case AstNode::kCountOperation: {
@@ -513,10 +518,12 @@ inline BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::Deser
   }
   case AstNode::kWhileStatement: {
     auto result = DeserializeWhileStatement(serialized_binast, bit_field, position, offset);
+    RecordBreakableStatement(original_offset, result.value);
     return {result.value, result.new_offset};
   }
   case AstNode::kDoWhileStatement: {
     auto result = DeserializeDoWhileStatement(serialized_binast, bit_field, position, offset);
+    RecordBreakableStatement(original_offset, result.value);
     return {result.value, result.new_offset};
   }
   case AstNode::kThisExpression: {
@@ -553,16 +560,23 @@ inline BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::Deser
   }
   case AstNode::kSwitchStatement: {
     auto result = DeserializeSwitchStatement(serialized_binast, bit_field, position, offset);
+    RecordBreakableStatement(original_offset, result.value);
     return {result.value, result.new_offset};
   }
   case AstNode::kThrow: {
     auto result = DeserializeThrow(serialized_binast, bit_field, position, offset);
     return {result.value, result.new_offset};
   }
+  case AstNode::kContinueStatement: {
+    auto result = DeserializeContinueStatement(serialized_binast, bit_field, position, offset);
+    return {result.value, result.new_offset};
+  }
+  case AstNode::kBreakStatement: {
+    auto result = DeserializeBreakStatement(serialized_binast, bit_field, position, offset);
+    return {result.value, result.new_offset};
+  }
   case AstNode::kForOfStatement:
   case AstNode::kSloppyBlockFunctionStatement:
-  case AstNode::kContinueStatement:
-  case AstNode::kBreakStatement:
   case AstNode::kTryFinallyStatement:
   case AstNode::kDebuggerStatement:
   case AstNode::kInitializeClassMembersStatement:
@@ -588,6 +602,37 @@ inline BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::Deser
     UNREACHABLE();
   }
   }
+}
+
+inline void BinAstDeserializer::RecordBreakableStatement(uint32_t offset, BreakableStatement* node) {
+  nodes_by_offset_[offset] = node;
+  PatchPendingNodeReferences(offset, node);
+}
+
+inline void BinAstDeserializer::PatchPendingNodeReferences(uint32_t offset, AstNode* node) {
+  if (patchable_fields_by_offset_.count(offset) == 0) {
+    return;
+  }
+  auto& fields_to_patch = patchable_fields_by_offset_[offset];
+  for (void** field : fields_to_patch) {
+    DCHECK(*field == nullptr);
+    *field = node;
+  }
+  patchable_fields_by_offset_.erase(offset);
+}
+
+inline BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::DeserializeNodeReference(uint8_t* bytes, int offset, void** patchable_field) {
+  auto node_offset = DeserializeUint32(bytes, offset);
+  offset = node_offset.new_offset;
+
+  auto result = nodes_by_offset_.find(node_offset.value);
+  if (result != nodes_by_offset_.end()) {
+    *patchable_field = result->second;
+    return {result->second, offset};
+  }
+
+  patchable_fields_by_offset_[node_offset.value].push_back(patchable_field);
+  return {nullptr, offset};
 }
 
 inline BinAstDeserializer::DeserializeResult<ReturnStatement*> BinAstDeserializer::DeserializeReturnStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {

--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -641,6 +641,26 @@ BinAstDeserializer::DeserializeSwitchStatement(uint8_t* serialized_binast,
   return {result, offset};
 }
 
+BinAstDeserializer::DeserializeResult<BreakStatement*>
+BinAstDeserializer::DeserializeBreakStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
+  BreakStatement* result = parser_->factory()->NewBreakStatement(nullptr, position);
+
+  auto target = DeserializeNodeReference(serialized_binast, offset, reinterpret_cast<void**>(&result->target_));
+  offset = target.new_offset;
+
+  return {result, offset};
+}
+
+BinAstDeserializer::DeserializeResult<ContinueStatement*>
+BinAstDeserializer::DeserializeContinueStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
+  ContinueStatement* result = parser_->factory()->NewContinueStatement(nullptr, position);
+
+  auto target = DeserializeNodeReference(serialized_binast, offset, reinterpret_cast<void**>(&result->target_));
+  offset = target.new_offset;
+
+  return {result, offset};
+}
+
 BinAstDeserializer::DeserializeResult<Throw*>
 BinAstDeserializer::DeserializeThrow(uint8_t* serialized_binast,
                                      uint32_t bit_field, int32_t position,

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -55,6 +55,10 @@ class BinAstDeserializer {
   DeserializeResult<std::array<bool, 16>> DeserializeUint16Flags(uint8_t* bytes, int offset);
   DeserializeResult<double> DeserializeDouble(uint8_t* bytes, int offset);
 
+  DeserializeResult<AstNode*> DeserializeNodeReference(uint8_t* bytes, int offset, void** patchable_field);
+  void RecordBreakableStatement(uint32_t offset, BreakableStatement* node);
+  void PatchPendingNodeReferences(uint32_t offset, AstNode* node);
+
   DeserializeResult<const char*> DeserializeCString(uint8_t* bytes, int offset);
   DeserializeResult<const AstRawString*> DeserializeRawString(uint8_t* bytes, int offset);
   DeserializeResult<std::nullptr_t> DeserializeStringTable(uint8_t* bytes, int offset);
@@ -110,6 +114,8 @@ class BinAstDeserializer {
   DeserializeResult<TryCatchStatement*> DeserializeTryCatchStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<RegExpLiteral*> DeserializeRegExpLiteral(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<SwitchStatement*> DeserializeSwitchStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
+  DeserializeResult<BreakStatement*> DeserializeBreakStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
+  DeserializeResult<ContinueStatement*> DeserializeContinueStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<Throw*> DeserializeThrow(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<std::nullptr_t> DeserializeNodeStub(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
 
@@ -118,6 +124,8 @@ class BinAstDeserializer {
   Handle<ByteArray> parse_data_;
   std::vector<const AstRawString*> string_table_vec_;
   std::unordered_map<uint32_t, Variable*> variables_by_id_;
+  std::unordered_map<uint32_t, AstNode*> nodes_by_offset_;
+  std::unordered_map<uint32_t, std::vector<void**>> patchable_fields_by_offset_;
 };
 
 }  // namespace internal

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -79,6 +79,8 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   virtual void VisitThisExpression(ThisExpression* this_expression) override;
   virtual void VisitRegExpLiteral(RegExpLiteral* reg_exp_literal) override;
   virtual void VisitSwitchStatement(SwitchStatement* switch_statement) override;
+  virtual void VisitBreakStatement(BreakStatement* break_statement) override;
+  virtual void VisitContinueStatement(ContinueStatement* continue_statement) override;
   virtual void VisitUnhandledNodeType(AstNode* node) override;
 
  private:
@@ -93,6 +95,7 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   void SerializeUint64(uint64_t value);
   void SerializeInt32(int32_t value);
   void SerializeDouble(double value);
+  void SerializeNodeReference(const AstNode* node);
   void SerializeCString(const char* str);
   void SerializeRawString(const AstRawString* s);
   void SerializeConsString(const AstConsString* cons_string);
@@ -115,11 +118,16 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   void VisitMaybeNode(AstNode* maybe_node);
   void ToDoBinAst(AstNode* node);
 
+  void RecordBreakableStatement(BreakableStatement* node);
+  void PatchPendingNodeReferences(const AstNode* node, size_t offset);
+
   AstValueFactory* ast_value_factory_;
   std::unordered_map<const AstRawString*, uint32_t> string_table_indices_;
   std::vector<uint8_t> byte_data_;
   std::unordered_map<Variable*, uint32_t> variable_ids_;
   std::unordered_map<VariableProxy*, int> var_proxy_ids;
+  std::unordered_map<const AstNode*, uint32_t> node_offsets_;
+  std::unordered_map<const AstNode*, std::vector<uint32_t>> patchable_node_reference_offsets_;
   int encountered_unhandled_nodes_;
   int skipped_functions_;
   int serialized_functions_;
@@ -355,6 +363,8 @@ inline bool BinAstSerializeVisitor::SerializeAst(AstNode* root) {
   DCHECK(literal != nullptr);
   SerializeStringTable(literal->raw_name());
   VisitNode(root);
+  // Make sure we eventually patched everything.
+  DCHECK(patchable_node_reference_offsets_.empty());
 
   if (encountered_unhandled_nodes_ > 0) {
     printf("Failed to serialize function: '");
@@ -381,6 +391,7 @@ inline bool BinAstSerializeVisitor::SerializeAst(AstNode* root) {
       return false;
     }
   }
+
 
   auto elapsed = std::chrono::high_resolution_clock::now() - start;
   long long microseconds = std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
@@ -612,6 +623,34 @@ inline void BinAstSerializeVisitor::SerializeScope(Scope* scope) {
   SerializeCommonScopeFields(scope);
 }
 
+inline void BinAstSerializeVisitor::PatchPendingNodeReferences(const AstNode* node, size_t node_offset) {
+  if (patchable_node_reference_offsets_.count(node) == 0) {
+    return;
+  }
+  CHECK(node_offset <= UINT32_MAX);
+  uint32_t bounded_node_offset = static_cast<uint32_t>(node_offset);
+  std::vector<uint32_t>& offsets_to_patch = patchable_node_reference_offsets_[node];
+  for (uint32_t patch_offset : offsets_to_patch) {
+    SerializeUint32(bounded_node_offset, patch_offset);
+  }
+  patchable_node_reference_offsets_.erase(node);
+}
+
+inline void BinAstSerializeVisitor::SerializeNodeReference(const AstNode* node) {
+  auto result = node_offsets_.find(node);
+  if (result != node_offsets_.end()) {
+    SerializeUint32(result->second);
+    return;
+  }
+
+  // We don't have an offset for this node yet, so record the offset to be patched
+  // when we eventually process it. Then serialize a placeholder value.
+  size_t current_offset = byte_data_.size();
+  CHECK(current_offset <= UINT32_MAX);
+  SerializeUint32(0);
+  patchable_node_reference_offsets_[node].push_back(static_cast<uint32_t>(current_offset));
+}
+
 inline void BinAstSerializeVisitor::SerializeAstNodeHeader(AstNode* node) {
   SerializeUint32(node->bit_field_);
   SerializeInt32(node->position_);
@@ -657,6 +696,13 @@ inline void BinAstSerializeVisitor::ToDoBinAst(AstNode* node) {
   encountered_unhandled_nodes_++;
 }
 
+inline void BinAstSerializeVisitor::RecordBreakableStatement(BreakableStatement* node) {
+  size_t current_offset = byte_data_.size();
+  DCHECK(current_offset <= UINT32_MAX);
+  node_offsets_.insert({{node, static_cast<uint32_t>(current_offset)}});
+  PatchPendingNodeReferences(node, current_offset);
+}
+
 inline void BinAstSerializeVisitor::VisitFunctionLiteral(FunctionLiteral* function_literal) {
   size_t start = byte_data_.size();
 
@@ -700,6 +746,8 @@ inline void BinAstSerializeVisitor::VisitFunctionLiteral(FunctionLiteral* functi
 }
 
 inline void BinAstSerializeVisitor::VisitBlock(Block* block) {
+  RecordBreakableStatement(block);
+  
   SerializeAstNodeHeader(block);
   if (block->scope()) {
     SerializeUint8(1);
@@ -780,6 +828,7 @@ inline void BinAstSerializeVisitor::VisitVariableProxyExpression(VariableProxyEx
 }
 
 inline void BinAstSerializeVisitor::VisitForStatement(ForStatement* for_statement) {
+  RecordBreakableStatement(for_statement);
   SerializeAstNodeHeader(for_statement);
 
   // TODO(binast): are we guaranteed that we'll have all of these nodes?
@@ -791,6 +840,7 @@ inline void BinAstSerializeVisitor::VisitForStatement(ForStatement* for_statemen
 }
 
 inline void BinAstSerializeVisitor::VisitForInStatement(ForInStatement* for_in_statement) {
+  RecordBreakableStatement(for_in_statement);
   SerializeAstNodeHeader(for_in_statement);
   VisitNode(for_in_statement->each());
   VisitNode(for_in_statement->subject());
@@ -798,12 +848,14 @@ inline void BinAstSerializeVisitor::VisitForInStatement(ForInStatement* for_in_s
 }
 
 inline void BinAstSerializeVisitor::VisitWhileStatement(WhileStatement* while_statement) {
+  RecordBreakableStatement(while_statement);
   SerializeAstNodeHeader(while_statement);
   VisitNode(while_statement->cond());
   VisitNode(while_statement->body());
 }
 
 inline void BinAstSerializeVisitor::VisitDoWhileStatement(DoWhileStatement* do_while_statement) {
+  RecordBreakableStatement(do_while_statement);
   SerializeAstNodeHeader(do_while_statement);
   VisitNode(do_while_statement->cond());
   VisitNode(do_while_statement->body());
@@ -955,12 +1007,23 @@ inline void BinAstSerializeVisitor::VisitRegExpLiteral(
 
 inline void BinAstSerializeVisitor::VisitSwitchStatement(
     SwitchStatement* switch_statement) {
+  RecordBreakableStatement(switch_statement);
   SerializeAstNodeHeader(switch_statement);
   VisitNode(switch_statement->tag());
   SerializeInt32(switch_statement->cases()->length());
   for (int i = 0; i < switch_statement->cases()->length(); i++) {
     SerializeCaseClause(switch_statement->cases()->at(i));
   }
+}
+
+inline void BinAstSerializeVisitor::VisitBreakStatement(BreakStatement* break_statement) {
+  SerializeAstNodeHeader(break_statement);
+  SerializeNodeReference(break_statement->target());
+}
+
+inline void BinAstSerializeVisitor::VisitContinueStatement(ContinueStatement* continue_statement) {
+  SerializeAstNodeHeader(continue_statement);
+  SerializeNodeReference(continue_statement->target());
 }
 
 inline void BinAstSerializeVisitor::VisitUnhandledNodeType(AstNode* node) {

--- a/src/parsing/binast-visitor.h
+++ b/src/parsing/binast-visitor.h
@@ -42,6 +42,8 @@ public:
   virtual void VisitThisExpression(ThisExpression* this_expression) = 0;
   virtual void VisitRegExpLiteral(RegExpLiteral* reg_exp_literal) = 0;
   virtual void VisitSwitchStatement(SwitchStatement* switch_statement) = 0;
+  virtual void VisitBreakStatement(BreakStatement* break_statement) = 0;
+  virtual void VisitContinueStatement(ContinueStatement* continue_statement) = 0;
   virtual void VisitUnhandledNodeType(AstNode* node) = 0;
 
   void VisitNode(AstNode* node) {
@@ -193,6 +195,16 @@ public:
 
       case AstNode::kSwitchStatement: {
         VisitSwitchStatement(static_cast<SwitchStatement*>(node));
+        break;
+      }
+
+      case AstNode::kBreakStatement: {
+        VisitBreakStatement(static_cast<BreakStatement*>(node));
+        break;
+      }
+
+      case AstNode::kContinueStatement: {
+        VisitContinueStatement(static_cast<ContinueStatement*>(node));
         break;
       }
 


### PR DESCRIPTION
BreakStatement and ContinueStatement reference other BreakableStatement nodes within
the AST. We'd like to represent these references as offsets into the serialized buffer,
however these referenced nodes could come before or after the Break/ContinueStatements
in the AST, i.e. we may not have an offset for them yet. This diff introduces some
additional bookkeeping done by both the serializer and the deserializer to track
the offsets of BreakableStatements as well as the offsets of things we need to patch
because we didn't have an offset available to us when we first processed the item.
When we do eventually process that BreakableStatement, we go back to placeholders
and patch them with the now-available offset/address.