### PR TITLE
Add proxy string table for each FunctionLiteral

### DIFF
--- a/src/codegen/code-stub-assembler.cc
+++ b/src/codegen/code-stub-assembler.cc
@@ -12861,7 +12861,7 @@ TNode<Code> CodeStubAssembler::GetSharedFunctionInfoCode(
   BIND(&check_is_uncompiled_data_with_preparse_data);
   Goto(&check_is_uncompiled_data_without_preparse_data);
   BIND(&check_is_uncompiled_data_with_binast_parse_data);
-  Goto(&check_is_uncompiled_data_with_inner_binast_parse_data);
+  Goto(&check_is_uncompiled_data_without_preparse_data);
   BIND(&check_is_uncompiled_data_with_inner_binast_parse_data);
   Goto(&check_is_uncompiled_data_without_preparse_data);
   BIND(&check_is_uncompiled_data_without_preparse_data);

--- a/src/interpreter/bytecode-generator.cc
+++ b/src/interpreter/bytecode-generator.cc
@@ -1191,12 +1191,6 @@ void BytecodeGenerator::AllocateDeferredConstants(LocalIsolate* isolate,
     Handle<SharedFunctionInfo> shared_info =
         Compiler::GetSharedFunctionInfo(expr, script, isolate);
     if (shared_info.is_null()) return SetStackOverflow();
-
-    if (!expr->uncompiled_data_with_inner_bin_ast_parse_data().is_null()) {
-      shared_info->set_function_data(
-          *expr->uncompiled_data_with_inner_bin_ast_parse_data());
-    }
-
     builder()->SetDeferredConstantPoolEntry(literal.second, shared_info);
   }
 

--- a/src/objects/objects-body-descriptors-inl.h
+++ b/src/objects/objects-body-descriptors-inl.h
@@ -274,10 +274,11 @@ class JSFinalizationRegistry::BodyDescriptor final : public BodyDescriptorBase {
 class SharedFunctionInfo::BodyDescriptor final : public BodyDescriptorBase {
  public:
   static bool IsValidSlot(Map map, HeapObject obj, int offset) {
-    static_assert(kEndOfWeakFieldsOffset == kStartOfStrongFieldsOffset,
-                  "Leverage that strong fields directly follow weak fields"
-                  "to call FixedBodyDescriptor<...>::IsValidSlot below");
-    return FixedBodyDescriptor<kStartOfWeakFieldsOffset,
+    // TODO(binast): Undo this change.
+    // static_assert(kEndOfWeakFieldsOffset == kStartOfStrongFieldsOffset,
+    //               "Leverage that strong fields directly follow weak fields "
+    //               "to call FixedBodyDescriptor<...>::IsValidSlot below");
+    return FixedBodyDescriptor<kStartOfStrongFieldsOffset,
                                kEndOfStrongFieldsOffset,
                                kAlignedSize>::IsValidSlot(map, obj, offset);
   }
@@ -285,7 +286,8 @@ class SharedFunctionInfo::BodyDescriptor final : public BodyDescriptorBase {
   template <typename ObjectVisitor>
   static inline void IterateBody(Map map, HeapObject obj, int object_size,
                                  ObjectVisitor* v) {
-    IterateCustomWeakPointer(obj, kFunctionDataOffset, v);
+    // TODO(binast): Undo this change.
+    // IterateCustomWeakPointer(obj, kFunctionDataOffset, v);
     IteratePointers(obj, SharedFunctionInfo::kStartOfStrongFieldsOffset,
                     SharedFunctionInfo::kEndOfStrongFieldsOffset, v);
   }

--- a/src/objects/objects.cc
+++ b/src/objects/objects.cc
@@ -5257,6 +5257,8 @@ void SharedFunctionInfo::DiscardCompiled(
     // If this is uncompiled data with a binary AST data, we can just
     // clear out the scope data and keep the uncompiled data.
     shared_info->ClearBinAstParseData();
+  } else if (shared_info->HasUncompiledDataWithInnerBinAstParseData()) {
+    shared_info->ClearInnerBinAstParseData();
   } else {
     // Create a new UncompiledData, without pre-parsed scope, and update the
     // function data to point to it. Use the raw function data setter to avoid
@@ -5462,7 +5464,6 @@ void SharedFunctionInfo::InitFromFunctionLiteral(
   ProducedPreparseData* scope_data = lit->produced_preparse_data();
   if (scope_data != nullptr) {
     Handle<PreparseData> preparse_data = scope_data->Serialize(isolate);
-
     data = isolate->factory()->NewUncompiledDataWithPreparseData(
         lit->GetInferredName(isolate), lit->start_position(),
         lit->end_position(), preparse_data);
@@ -5475,6 +5476,7 @@ void SharedFunctionInfo::InitFromFunctionLiteral(
   }
 
   shared_info->set_uncompiled_data(*data);
+  DCHECK(lit->has_uncompiled_data_with_inner_bin_ast_parse_data() || !shared_info->HasUncompiledDataWithInnerBinAstParseData());
 }
 
 template EXPORT_TEMPLATE_DEFINE(V8_EXPORT_PRIVATE) void SharedFunctionInfo::
@@ -5607,6 +5609,8 @@ void SharedFunctionInfo::SetPosition(int start_position, int end_position) {
     } else if (HasUncompiledDataWithBinAstParseData()) {
       // Clear out binary AST data
       ClearBinAstParseData();
+    } else if (HasUncompiledDataWithInnerBinAstParseData()) {
+      ClearInnerBinAstParseData();
     }
     uncompiled_data().set_start_position(start_position);
     uncompiled_data().set_end_position(end_position);

--- a/src/objects/shared-function-info.tq
+++ b/src/objects/shared-function-info.tq
@@ -52,7 +52,7 @@ bitfield struct SharedFunctionInfoFlags2 extends uint8 {
 }
 
 extern class SharedFunctionInfo extends HeapObject {
-  weak function_data: Object;
+  function_data: Object;
   name_or_scope_info: String|NoSharedNameSentinel|ScopeInfo;
   outer_scope_info_or_feedback_metadata: HeapObject;
   script_or_debug_info: Script|DebugInfo|Undefined;

--- a/src/parsing/binast-deserializer-inl.h
+++ b/src/parsing/binast-deserializer-inl.h
@@ -135,6 +135,8 @@ inline BinAstDeserializer::DeserializeResult<const char*> BinAstDeserializer::De
 }
 
 inline BinAstDeserializer::DeserializeResult<const AstRawString*> BinAstDeserializer::DeserializeRawString(uint8_t* serialized_ast, int offset) {
+  auto original_offset = offset;
+
   auto is_one_byte = DeserializeUint8(serialized_ast, offset);
   offset = is_one_byte.new_offset;
 
@@ -155,38 +157,54 @@ inline BinAstDeserializer::DeserializeResult<const AstRawString*> BinAstDeserial
     Vector<const byte> literal_bytes;
     s = parser_->ast_value_factory()->GetString(hash_field.value, is_one_byte.value, literal_bytes);
   }
-  string_table_vec_.push_back(s);
+  DCHECK(strings_by_offset_.count(original_offset) == 0);
+  strings_by_offset_[original_offset] = s;
   return {s, offset};
 }
 
-inline BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::DeserializeStringTable(uint8_t* serialized_ast, int offset) {
-  auto num_non_constant_entries = DeserializeUint32(serialized_ast, offset);
-  offset = num_non_constant_entries.new_offset;
+inline BinAstDeserializer::DeserializeResult<const AstRawString*> BinAstDeserializer::DeserializeProxyString(uint8_t* serialized_ast, int offset) {
+  auto raw_offset = DeserializeUint32(serialized_ast, offset);
+  offset = raw_offset.new_offset;
 
-  string_table_vec_.reserve(num_non_constant_entries.value + parser_->ast_value_factory()->string_constants_->string_table()->occupancy());
-
-  for (uint32_t i = 0; i < num_non_constant_entries.value; ++i) {
-    auto string = DeserializeRawString(serialized_ast, offset);
-    offset = string.new_offset;
+  {
+    auto result = strings_by_offset_.find(raw_offset.value);
+    if (result != strings_by_offset_.end()) {
+      return {result->second, offset};
+    }
   }
 
-  for (base::HashMap::Entry* entry = parser_->ast_value_factory()->string_constants_->string_table()->Start(); entry != nullptr; entry = parser_->ast_value_factory()->string_constants_->string_table()->Next(entry)) {
-    const AstRawString* s = reinterpret_cast<const AstRawString*>(entry->key);
-    string_table_vec_.push_back(s);
+  auto result = DeserializeRawString(serialized_ast, raw_offset.value);
+  return {result.value, offset};
+} 
+
+inline BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::DeserializeStringTable(uint8_t* serialized_ast, int offset) {
+  auto end_offset = DeserializeUint32(serialized_ast, offset);
+  return {nullptr, end_offset.value};
+}
+
+inline BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::DeserializeProxyStringTable(uint8_t* serialized_ast, int offset) {
+  auto num_proxy_strings = DeserializeUint32(serialized_ast, offset);
+  offset = num_proxy_strings.new_offset;
+
+  strings_by_offset_.reserve(num_proxy_strings.value);
+
+  for (uint32_t i = 0; i < num_proxy_strings.value; ++i) {
+    auto string = DeserializeProxyString(serialized_ast, offset);
+    offset = string.new_offset;
   }
 
   return {nullptr, offset};
 }
 
 inline BinAstDeserializer::DeserializeResult<const AstRawString*> BinAstDeserializer::DeserializeRawStringReference(uint8_t* serialized_ast, int offset) {
-  auto string_table_index = DeserializeVarUint32(serialized_ast, offset);
-  offset = string_table_index.new_offset;
-  if (string_table_index.value == 0) {
+  auto string_table_offset = DeserializeVarUint32(serialized_ast, offset);
+  offset = string_table_offset.new_offset;
+  if (string_table_offset.value == 0) {
     return {nullptr, offset};
   }
 
-  DCHECK(string_table_index.value > 0 && string_table_index.value <= string_table_vec_.size());
-  const AstRawString* result = string_table_vec_[string_table_index.value - 1];
+  DCHECK(strings_by_offset_.count(string_table_offset.value) > 0);
+  const AstRawString* result = strings_by_offset_[string_table_offset.value];
   return {result, offset};
 }
 
@@ -439,7 +457,6 @@ inline BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::Deser
               result.value->GetInferredName(isolate_),
               result.value->start_position(), result.value->end_position(),
               parse_data_, start_offset.value, length.value);
-
       result.value->set_uncompiled_data_with_inner_bin_ast_parse_data(data);
     }
 

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -61,7 +61,9 @@ class BinAstDeserializer {
 
   DeserializeResult<const char*> DeserializeCString(uint8_t* bytes, int offset);
   DeserializeResult<const AstRawString*> DeserializeRawString(uint8_t* bytes, int offset);
+  DeserializeResult<const AstRawString*> DeserializeProxyString(uint8_t* serialized_ast, int offset);
   DeserializeResult<std::nullptr_t> DeserializeStringTable(uint8_t* bytes, int offset);
+  DeserializeResult<std::nullptr_t> DeserializeProxyStringTable(uint8_t* serialized_ast, int offset);
   DeserializeResult<const AstRawString*> DeserializeRawStringReference(uint8_t* bytes, int offset);
   DeserializeResult<AstConsString*> DeserializeConsString(uint8_t* bytes, int offset);
 
@@ -122,7 +124,7 @@ class BinAstDeserializer {
   Isolate* isolate_;
   Parser* parser_;
   Handle<ByteArray> parse_data_;
-  std::vector<const AstRawString*> string_table_vec_;
+  std::unordered_map<uint32_t, const AstRawString*> strings_by_offset_;
   std::unordered_map<uint32_t, Variable*> variables_by_id_;
   std::unordered_map<uint32_t, AstNode*> nodes_by_offset_;
   std::unordered_map<uint32_t, std::vector<void**>> patchable_fields_by_offset_;


### PR DESCRIPTION
Previously every function that we deserialized had to first deserialize
the string table at the beginning of the serialized AST. Since we serialize
a single monolithic buffer for a functions within a top-level nested function
tree, this led to functions having to deserialize lots of strings that they
would never use.

After this diff, while serializing we track which strings are used by each
function literal. We then record the offsets of those strings at the beginning
of the portion of the serialized buffer for that function literal. This way,
when we deserialize a sub-section of the buffer corresponding to an inner function
we only need to deserialize the strings at those offsets in the global string
table table.