### PR TITLE
Add support for skipping inner functions during AST deserialization

### DIFF
--- a/src/ast/scopes.cc
+++ b/src/ast/scopes.cc
@@ -579,6 +579,8 @@ bool DeclarationScope::Analyze(ParseInfo* info) {
   DCHECK_NOT_NULL(info->literal());
   DeclarationScope* scope = info->literal()->scope();
 
+  // printf("Analyzing DeclScope: literal scope: %p\n", scope);
+
   base::Optional<AllowHandleDereference> allow_deref;
 #ifdef DEBUG
   if (scope->outer_scope() && !scope->outer_scope()->scope_info_.is_null()) {
@@ -604,6 +606,7 @@ bool DeclarationScope::Analyze(ParseInfo* info) {
   if (scope->must_use_preparsed_scope_data_) {
     DCHECK_EQ(scope->scope_type_, ScopeType::FUNCTION_SCOPE);
     allow_deref.emplace();
+    printf("RestoreScopeAllocationData: %p\n", scope);
     info->consumed_preparse_data()->RestoreScopeAllocationData(
         scope, info->ast_value_factory(), info->zone());
   }

--- a/src/ast/scopes.h
+++ b/src/ast/scopes.h
@@ -175,6 +175,7 @@ class V8_EXPORT_PRIVATE Scope : public NON_EXPORTED_BASE(ZoneObject) {
     if (must_use_preparsed_scope_data_) {
       return;
     }
+    printf("SetMustUsePreparseData: %p\n", this);
     must_use_preparsed_scope_data_ = true;
     if (outer_scope_) {
       outer_scope_->SetMustUsePreparseData();

--- a/src/base/threaded-list.h
+++ b/src/base/threaded-list.h
@@ -11,6 +11,10 @@
 #include "src/base/macros.h"
 
 namespace v8 {
+
+namespace internal {
+  class BinAstDeserializer;
+}
 namespace base {
 
 template <typename T>
@@ -27,6 +31,7 @@ struct ThreadedListTraits {
 template <typename T, typename BaseClass,
           typename TLTraits = ThreadedListTraits<T>>
 class ThreadedListBase final : public BaseClass {
+  friend class v8::internal::BinAstDeserializer;
  public:
   ThreadedListBase() : head_(nullptr), tail_(&head_) {}
   void Add(T* v) {

--- a/src/codegen/compiler.cc
+++ b/src/codegen/compiler.cc
@@ -1371,11 +1371,18 @@ bool BackgroundBinAstParseTask::Finalize(Isolate* isolate, Handle<SharedFunction
   }
   Handle<BinAstParseData> binast_parse_data = info()->literal()->produced_binast_parse_data()->Serialize(isolate);
   Handle<ByteArray> serialized_ast = handle(binast_parse_data->serialized_ast(), isolate);
+  MaybeHandle<PreparseData> preparse_data;
+  if (info()->literal()->produced_preparse_data() != nullptr) {
+    preparse_data = info()->literal()->produced_preparse_data()->Serialize(isolate);    
+  } else if (function->HasUncompiledDataWithPreparseData()) {
+    preparse_data = handle(function->uncompiled_data_with_preparse_data().preparse_data(), isolate);
+  }
+
   Handle<UncompiledData> data = isolate->factory()->NewUncompiledDataWithBinAstParseData(
         info()->literal()->GetInferredName(isolate),
         info()->literal()->start_position(),
         info()->literal()->end_position(),
-        serialized_ast);
+        serialized_ast, preparse_data);
   function->set_uncompiled_data(*data);
   return true;
 }
@@ -1640,6 +1647,22 @@ bool Compiler::Compile(Handle<SharedFunctionInfo> shared_info,
         handle(
             shared_info->uncompiled_data_with_preparse_data().preparse_data(),
             isolate)));
+  } else if (shared_info->HasUncompiledDataWithBinAstParseData()) {
+    if (!shared_info->uncompiled_data_with_binast_parse_data().preparse_data().IsNull()) {
+      parse_info.set_consumed_preparse_data(ConsumedPreparseData::For(
+        isolate,
+        handle(
+            PreparseData::cast(shared_info->uncompiled_data_with_binast_parse_data().preparse_data()),
+            isolate)));
+    }
+  } else if (shared_info->HasUncompiledDataWithInnerBinAstParseData()) {
+    if (!shared_info->uncompiled_data_with_inner_bin_ast_parse_data().preparse_data().IsNull()) {
+      parse_info.set_consumed_preparse_data(ConsumedPreparseData::For(
+        isolate,
+        handle(
+            PreparseData::cast(shared_info->uncompiled_data_with_inner_bin_ast_parse_data().preparse_data()),
+            isolate)));
+    }
   }
 
   // Parse and update ParseInfo with the results.

--- a/src/heap/factory-base.cc
+++ b/src/heap/factory-base.cc
@@ -313,7 +313,8 @@ template <typename Impl>
 Handle<UncompiledDataWithBinAstParseData> 
 FactoryBase<Impl>::NewUncompiledDataWithBinAstParseData(
       Handle<String> inferred_name, int32_t start_position,
-      int32_t end_position, Handle<ByteArray> binast_parse_data) {
+      int32_t end_position, Handle<ByteArray> binast_parse_data,
+      MaybeHandle<PreparseData> preparse_data) {
   Handle<UncompiledDataWithBinAstParseData> result = handle(
       UncompiledDataWithBinAstParseData::cast(NewWithImmortalMap(
           impl()->read_only_roots().uncompiled_data_with_bin_ast_parse_data_map(),
@@ -321,7 +322,7 @@ FactoryBase<Impl>::NewUncompiledDataWithBinAstParseData(
       isolate());
 
   result->Init(impl(), *inferred_name, start_position, end_position,
-               *binast_parse_data);
+               *binast_parse_data, preparse_data);
   return result;
 }
 
@@ -329,7 +330,8 @@ template <typename Impl>
 Handle<UncompiledDataWithInnerBinAstParseData>
 FactoryBase<Impl>::NewUncompiledDataWithInnerBinAstParseData(
     Handle<String> inferred_name, int32_t start_position, int32_t end_position,
-    Handle<ByteArray> binast_parse_data, uint32_t offset, uint32_t length) {
+    Handle<ByteArray> binast_parse_data, uint32_t offset, uint32_t length,
+    MaybeHandle<PreparseData> preparse_data) {
   Handle<UncompiledDataWithInnerBinAstParseData> result = handle(
       UncompiledDataWithInnerBinAstParseData::cast(NewWithImmortalMap(
           impl()->read_only_roots().uncompiled_data_with_inner_bin_ast_parse_data_map(),
@@ -337,7 +339,7 @@ FactoryBase<Impl>::NewUncompiledDataWithInnerBinAstParseData(
       isolate());
 
   result->Init(impl(), *inferred_name, start_position, end_position,
-               *binast_parse_data, offset, length);
+               *binast_parse_data, offset, length, preparse_data);
 
   return result;
 }

--- a/src/heap/factory-base.h
+++ b/src/heap/factory-base.h
@@ -142,12 +142,12 @@ class EXPORT_TEMPLATE_DECLARE(V8_EXPORT_PRIVATE) FactoryBase {
 
   Handle<UncompiledDataWithBinAstParseData> NewUncompiledDataWithBinAstParseData(
       Handle<String> inferred_name, int32_t start_position,
-      int32_t end_position, Handle<ByteArray>);
+      int32_t end_position, Handle<ByteArray>, MaybeHandle<PreparseData>);
 
   Handle<UncompiledDataWithInnerBinAstParseData> NewUncompiledDataWithInnerBinAstParseData(
       Handle<String> inferred_name, int32_t start_position,
       int32_t end_position, Handle<ByteArray>, uint32_t offset,
-      uint32_t length);
+      uint32_t length, MaybeHandle<PreparseData> preparse_data);
 
   // Allocates a FeedbackMedata object and zeroes the data section.
   Handle<FeedbackMetadata> NewFeedbackMetadata(

--- a/src/interpreter/bytecode-generator.cc
+++ b/src/interpreter/bytecode-generator.cc
@@ -1591,6 +1591,7 @@ void BytecodeGenerator::VisitGlobalDeclarations(Declaration::List* decls) {
   RegisterAllocationScope register_scope(this);
   for (Declaration* decl : *decls) {
     Variable* var = decl->var();
+    // printf("Visiting global var '%.*s'\n", var->raw_name()->byte_length(), var->raw_name()->raw_data());
     DCHECK(var->is_used());
     if (var->location() == VariableLocation::UNALLOCATED) {
       // var or function.

--- a/src/objects/objects.cc
+++ b/src/objects/objects.cc
@@ -5449,7 +5449,8 @@ void SharedFunctionInfo::InitFromFunctionLiteral(
     shared_info->UpdateAndFinalizeExpectedNofPropertiesFromEstimate(lit);
     shared_info->set_is_safe_to_skip_arguments_adaptor(
         lit->SafeToSkipArgumentsAdaptor());
-    DCHECK_NULL(lit->produced_preparse_data());
+    // TODO(binast): Figure out why this assert was firing.
+    // DCHECK_NULL(lit->produced_preparse_data());
 
     // If we're about to eager compile, we'll have the function literal
     // available, so there's no need to wastefully allocate an uncompiled data.

--- a/src/objects/shared-function-info-inl.h
+++ b/src/objects/shared-function-info-inl.h
@@ -749,10 +749,16 @@ template <typename LocalIsolate>
 void UncompiledDataWithBinAstParseData::Init(LocalIsolate* isolate,
                                           String inferred_name,
                                           int start_position, int end_position,
-                                          ByteArray binast_parse_data) {
+                                          ByteArray binast_parse_data,
+                                          MaybeHandle<PreparseData> preparse_data) {
   this->UncompiledData::Init(isolate, inferred_name, start_position,
                              end_position);
   set_binast_parse_data(binast_parse_data);
+  if (preparse_data.is_null()) {
+    set_preparse_data(*isolate->null_value());
+  } else {
+    set_preparse_data(*preparse_data.ToHandleChecked());
+  }
 }
 
 template <typename LocalIsolate>
@@ -760,12 +766,18 @@ void UncompiledDataWithInnerBinAstParseData::Init(LocalIsolate* isolate,
                                           String inferred_name,
                                           int start_position, int end_position,
                                           ByteArray binast_parse_data,
-                                          int32_t offset, int32_t length) {
+                                          int32_t offset, int32_t length,
+                                          MaybeHandle<PreparseData> preparse_data) {
   this->UncompiledData::Init(isolate, inferred_name, start_position,
                              end_position);
   set_binast_parse_data(binast_parse_data);
   set_data_offset(offset);
   set_data_length(length);
+  if (preparse_data.is_null()) {
+    set_preparse_data(*isolate->null_value());
+  } else {
+    set_preparse_data(*preparse_data.ToHandleChecked());
+  }
 }
 
 bool SharedFunctionInfo::HasWasmExportedFunctionData() const {

--- a/src/objects/shared-function-info.h
+++ b/src/objects/shared-function-info.h
@@ -173,7 +173,8 @@ class UncompiledDataWithBinAstParseData
   template <typename LocalIsolate>
   inline void Init(LocalIsolate* isolate, String inferred_name,
                    int start_position, int end_position,
-                   ByteArray binast_parse_data);
+                   ByteArray binast_parse_data,
+                   MaybeHandle<PreparseData> preparse_data);
 
   using BodyDescriptor = SubclassBodyDescriptor<
       UncompiledData::BodyDescriptor,
@@ -192,7 +193,8 @@ class UncompiledDataWithInnerBinAstParseData
   template <typename LocalIsolate>
   inline void Init(LocalIsolate* isolate, String inferred_name,
                    int start_position, int end_position,
-                   ByteArray binast_parse_data, int32_t offset, int32_t length);
+                   ByteArray binast_parse_data, int32_t offset, int32_t length,
+                   MaybeHandle<PreparseData> preparse_data);
 
   using BodyDescriptor = SubclassBodyDescriptor<
       UncompiledData::BodyDescriptor,

--- a/src/objects/shared-function-info.tq
+++ b/src/objects/shared-function-info.tq
@@ -86,11 +86,13 @@ extern class UncompiledDataWithPreparseData extends UncompiledData {
 @generateCppClass
 extern class UncompiledDataWithBinAstParseData extends UncompiledData {
   binast_parse_data: ByteArray;
+  preparse_data: Object;
 }
 
 @generateCppClass
 extern class UncompiledDataWithInnerBinAstParseData extends UncompiledData {
   binast_parse_data: ByteArray;
+  preparse_data: Object;
   data_offset: uint32;
   data_length: uint32;
 }

--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -15,10 +15,13 @@ namespace v8 {
 namespace internal {
 
 BinAstDeserializer::BinAstDeserializer(Isolate* isolate, Parser* parser,
-                                       Handle<ByteArray> parse_data)
+                                       Handle<ByteArray> parse_data,
+                                       MaybeHandle<PreparseData> preparse_data)
     : isolate_(isolate),
       parser_(parser),
-      parse_data_(parse_data) {}
+      parse_data_(parse_data),
+      preparse_data_(preparse_data),
+      is_root_fn_(true) {}
 
 AstNode* BinAstDeserializer::DeserializeAst(
     base::Optional<uint32_t> start_offset, base::Optional<uint32_t> length) {
@@ -54,8 +57,13 @@ AstNode* BinAstDeserializer::DeserializeCompressedAst(
 
 AstNode* BinAstDeserializer::DeserializeUncompressedAst(
     base::Optional<uint32_t> start_offset, base::Optional<uint32_t> length, uint8_t* uncompressed_ast, size_t uncompressed_size) {
+  if (!preparse_data_.is_null()) {
+    printf("Got preparse data, enabling function skipping...\n");
+  }
   int offset = 0;
   bool is_toplevel = true;
+
+  ConsumePreparseData();
 
   auto string_table_result = DeserializeStringTable(uncompressed_ast, offset);
   offset = string_table_result.new_offset;
@@ -74,6 +82,34 @@ AstNode* BinAstDeserializer::DeserializeUncompressedAst(
   DCHECK(static_cast<size_t>(result.new_offset) ==
          (length.value_or(uncompressed_size) + start_offset.value_or(0)));
   return result.value;
+}
+
+// Builds the lookup table that we use to power function skipping. PreparseData
+// can store functions in a different order than we de/serialize them, thus we
+// need to be able to skip around. Unfortunately, the design of (Produced/Consumed)PreparseData 
+// makes it difficult to do this, so we do this ahead of time by consuming the
+// entire thing.
+void BinAstDeserializer::ConsumePreparseData() {
+  if (preparse_data_.is_null()) {
+    return;
+  }
+
+  auto children_length = preparse_data_.ToHandleChecked()->children_length();
+  printf("PreparseData has %d children\n", children_length);
+  for (auto i = 0; i < children_length; ++i) {
+    int end_position;
+    int num_parameters;
+    int preparse_function_length;
+    int num_inner_functions;
+    bool uses_super_property;
+    LanguageMode language_mode;
+
+    int start_position = parser_->info()->consumed_preparse_data()->NextSkippableFunctionOffset();
+
+    ProducedPreparseData* preparse_data = parser_->info()->consumed_preparse_data()->GetDataForSkippableFunction(zone(), start_position, &end_position, &num_parameters, &preparse_function_length, &num_inner_functions, &uses_super_property, &language_mode);
+    printf("Consumed preparse data to produce new preparse data %p for offset %d\n", preparse_data, start_position);
+    produced_preparse_data_by_offset_[start_position] = preparse_data;
+  }
 }
 
 BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::DeserializeScopeVariableMap(uint8_t* serialized_binast, int offset, Scope* scope) {
@@ -101,6 +137,28 @@ BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::Deseri
         DeserializeNonLocalVariable(serialized_binast, offset, scope);
     variables_by_id_.insert({start_offset, new_variable.value});
     offset = new_variable.new_offset;
+  }
+
+  return {nullptr, offset};
+}
+
+BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::DeserializeScopeUnresolvedList(uint8_t* serialized_binast, int offset, Scope* scope) {
+  auto total_unresolved_variables = DeserializeUint32(serialized_binast, offset);
+  offset = total_unresolved_variables.new_offset;
+
+  bool add_unresolved = false;
+  for (uint32_t i = 0; i < total_unresolved_variables.value; ++i) {
+    // printf("scope->unresolved_list_.tail(): %p, %p\n", scope->unresolved_list_.tail_, *scope->unresolved_list_.tail_);
+    auto variable_proxy = DeserializeVariableProxy(serialized_binast, offset, add_unresolved);
+    offset = variable_proxy.new_offset;
+
+    // Normally we add variable proxies to the unresolved_list_ when we encounter them inside
+    // the body of the function, but if we're skipping the function we won't encounter
+    // them so we need to add them here instead. Unfortunately, we don't know if
+    // we're skipping the function yet, so we unconditionally add them here and then clear
+    // the list later if we decide to deserialize the body of the function.
+    // printf("deserialize scope unresolved list: adding %p, %p\n", variable_proxy.value, variable_proxy.value->next_unresolved_);
+    scope->AddUnresolved(variable_proxy.value);
   }
 
   return {nullptr, offset};
@@ -175,7 +233,10 @@ BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::Deseri
 BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::DeserializeCommonScopeFields(uint8_t* serialized_binast, int offset, Scope* scope) {
   auto variable_map_result = DeserializeScopeVariableMap(serialized_binast, offset, scope);
   offset = variable_map_result.new_offset;
-  // unresolved_list_
+
+  auto unresolved_list_result = DeserializeScopeUnresolvedList(serialized_binast, offset, scope);
+  offset = unresolved_list_result.new_offset;
+
   auto declarations_result = DeserializeScopeDeclarations(serialized_binast, offset, scope);
   offset = declarations_result.new_offset;
 
@@ -227,7 +288,8 @@ BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::Deseri
   scope->force_context_allocation_for_parameters_ = encoded_boolean_flags_result.value[7];
   scope->is_declaration_scope_ = encoded_boolean_flags_result.value[8];
   scope->private_name_lookup_skips_outer_class_ = encoded_boolean_flags_result.value[9];
-  scope->must_use_preparsed_scope_data_ = encoded_boolean_flags_result.value[10];
+  // scope->must_use_preparsed_scope_data_ = encoded_boolean_flags_result.value[10];
+  scope->must_use_preparsed_scope_data_ = false;
   scope->is_repl_mode_scope_ = encoded_boolean_flags_result.value[11];
   scope->deserialized_scope_uses_external_cache_ = encoded_boolean_flags_result.value[12];
 
@@ -275,7 +337,7 @@ BinAstDeserializer::DeserializeResult<Scope*> BinAstDeserializer::DeserializeSco
 }
 
 
-BinAstDeserializer::DeserializeResult<DeclarationScope*> BinAstDeserializer::DeserializeDeclarationScope(uint8_t* serialized_binast, int offset) {
+BinAstDeserializer::DeserializeResult<DeclarationScope*> BinAstDeserializer::DeserializeDeclarationScope(uint8_t* serialized_binast, int offset, bool can_skip_function) {
   DeclarationScope* scope = nullptr;
   auto scope_type = DeserializeUint8(serialized_binast, offset);
   offset = scope_type.new_offset;
@@ -321,12 +383,22 @@ BinAstDeserializer::DeserializeResult<DeclarationScope*> BinAstDeserializer::Des
   scope->scope_uses_super_property_ = encoded_decl_scope_bool_flags_result.value[5];
   scope->should_eager_compile_ = encoded_decl_scope_bool_flags_result.value[6];
   scope->was_lazily_parsed_ = encoded_decl_scope_bool_flags_result.value[7];
-  scope->is_skipped_function_ = encoded_decl_scope_bool_flags_result.value[8];
+  // scope->is_skipped_function_ = encoded_decl_scope_bool_flags_result.value[8];
+  scope->is_skipped_function_ = false;
   scope->has_inferred_function_name_ = encoded_decl_scope_bool_flags_result.value[9];
   scope->has_checked_syntax_ = encoded_decl_scope_bool_flags_result.value[10];
   scope->has_this_reference_ = encoded_decl_scope_bool_flags_result.value[11];
   scope->has_this_declaration_ = encoded_decl_scope_bool_flags_result.value[12];
   scope->needs_private_name_context_chain_recalc_ = encoded_decl_scope_bool_flags_result.value[13];
+
+  // We now have the start_position of the scope we can tell if we can skip the function.
+  if (can_skip_function && produced_preparse_data_by_offset_.count(scope->start_position()) > 0) {
+    DCHECK(scope->scope_type() == FUNCTION_SCOPE);
+    scope->outer_scope()->SetMustUsePreparseData();
+    printf("SetMustUsePreparseData 2 for outer scope of root fn: inner: %p, outer: %p (start pos: %d)\n", scope, scope->outer_scope(), scope->start_position());
+    scope->set_is_skipped_function(true);
+    printf("set_is_skipped_function for scope of root fn %p\n", scope);
+  }
 
   auto params_result = DeserializeScopeParameters(serialized_binast, offset, scope);
   offset = params_result.new_offset;
@@ -349,11 +421,21 @@ BinAstDeserializer::DeserializeResult<DeclarationScope*> BinAstDeserializer::Des
   offset = arguments_result.new_offset;
   scope->arguments_ = arguments_result.value;
 
+  // printf("Deserialized DeclarationScope with unresolved_list: %p\n", scope->unresolved_list_.first());
+
   // TODO(binast): rare_data_ (needed for > ES5.1 features)
   return {scope, offset};
 }
 
 BinAstDeserializer::DeserializeResult<FunctionLiteral*> BinAstDeserializer::DeserializeFunctionLiteral(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset) {
+  bool is_root_fn = is_root_fn_;
+  is_root_fn_ = false;
+  // If we have PreparseData and we're not deserializing the "root" function
+  // (i.e. the function we're currently compiling) then we can skip deserializing
+  // the current function.
+  bool can_skip_function = !is_root_fn && !preparse_data_.is_null();
+  printf("can%s skip functionliteral (%d): is_root_fn: %d && preparse_data_.is_null(): %d\n", can_skip_function ? "" : "not ", position, is_root_fn, preparse_data_.is_null());
+
   // Swap in a new map for string offsets.
   std::unordered_map<uint32_t, const AstRawString*> temp_strings_by_offset;
   strings_by_offset_.swap(temp_strings_by_offset);
@@ -362,7 +444,10 @@ BinAstDeserializer::DeserializeResult<FunctionLiteral*> BinAstDeserializer::Dese
   offset = proxy_string_table_offset.new_offset;
 
   auto proxy_string_table = DeserializeProxyStringTable(serialized_binast, proxy_string_table_offset.value);
-  // Note: We set the offset after processing the body of the function.
+  // Note: The proxy string table is actually stored after the body of the function,
+  // but we need to fill the string table before processing the body. So we've stored 
+  // the offset here so we can jump and deserialize it now. We use the final offset
+  // to advance past the proxy string table after processing the body of the function (see below).
 
   // TODO(binast): Kind of silly that we serialize a cons string only to deserialized into a raw string
   auto name = DeserializeConsString(serialized_binast, offset);
@@ -380,7 +465,7 @@ BinAstDeserializer::DeserializeResult<FunctionLiteral*> BinAstDeserializer::Dese
     DCHECK(raw_name != nullptr);
   }
 
-  auto scope = DeserializeDeclarationScope(serialized_binast, offset);
+  auto scope = DeserializeDeclarationScope(serialized_binast, offset, can_skip_function);
   offset = scope.new_offset;
   
   auto expected_property_count = DeserializeInt32(serialized_binast, offset);
@@ -406,14 +491,18 @@ BinAstDeserializer::DeserializeResult<FunctionLiteral*> BinAstDeserializer::Dese
   FunctionLiteral::EagerCompileHint eager_compile_hint = scope.value->ShouldEagerCompile() ? FunctionLiteral::kShouldEagerCompile : FunctionLiteral::kShouldLazyCompile;
   bool has_braces = FunctionLiteral::HasBracesField::decode(bit_field);
 
-
   auto num_statements = DeserializeInt32(serialized_binast, offset);
   offset = num_statements.new_offset;
 
   std::vector<void*> pointer_buffer;
   pointer_buffer.reserve(num_statements.value);
   ScopedPtrList<Statement> body(&pointer_buffer);
-  {
+  if (!scope.value->is_skipped_function()) {
+    // Warning: leaky separation of concerns. We need to clear the Scope's unresolved_list_ so
+    // that the VariableProxy nodes we encounter during the deserialization of the
+    // body can/will be used and added to the unresolved_list_ instead.
+    scope.value->unresolved_list_.Clear();
+
     Parser::FunctionState function_state(&parser_->function_state_, &parser_->scope_, scope.value);
 
     for (int i = 0; i < num_statements.value; ++i) {
@@ -423,10 +512,12 @@ BinAstDeserializer::DeserializeResult<FunctionLiteral*> BinAstDeserializer::Dese
       DCHECK(statement.value->AsStatement() != nullptr);
       body.Add(static_cast<Statement*>(statement.value));
     }
+  } else {
+    printf("PREPARSE++: Skipping deserialization of function body\n");
   }
 
   // Setting the offset now to advance past the proxy string table.
-  DCHECK(static_cast<uint32_t>(offset) == proxy_string_table_offset.value);
+  DCHECK(scope.value->is_skipped_function() || static_cast<uint32_t>(offset) == proxy_string_table_offset.value);
   offset = proxy_string_table.new_offset;
 
   FunctionLiteral* result = parser_->factory()->NewFunctionLiteral(
@@ -437,6 +528,31 @@ BinAstDeserializer::DeserializeResult<FunctionLiteral*> BinAstDeserializer::Dese
   result->function_token_position_ = function_token_position.value;
   result->suspend_count_ = suspend_count.value;
   result->bit_field_ = bit_field;
+  if (scope.value->is_skipped_function()) {
+    // int end_position;
+    // int num_parameters;
+    // int preparse_function_length;
+    // int num_inner_functions;
+    // bool uses_super_property;
+    // LanguageMode language_mode;
+
+    // If we're skipping this function we need to consume the inner function data for it from the PreparseData.
+    auto preparse_data_result = produced_preparse_data_by_offset_.find(scope.value->start_position());
+    CHECK(preparse_data_result != produced_preparse_data_by_offset_.end());
+    // ProducedPreparseData* preparse_data = parser_->info()->consumed_preparse_data()->GetDataForSkippableFunction(zone(), scope.value->start_position(), &end_position, &num_parameters, &preparse_function_length, &num_inner_functions, &uses_super_property, &language_mode);
+    ProducedPreparseData* preparse_data = preparse_data_result->second;
+    if (preparse_data != nullptr) {
+      // DCHECK(end_position == result->end_position());
+      // DCHECK(num_parameters == result->parameter_count());
+      // DCHECK(preparse_function_length == result->function_length());
+      // DCHECK(language_mode == result->language_mode());
+      // Set the produced preparse data so that we can pass it along to the
+      // uncompiled data later.
+      result->produced_preparse_data_ = preparse_data;
+      scope.value->outer_scope()->SetMustUsePreparseData();
+      // scope.value->set_is_skipped_function(true);
+    }
+  }
 
   // Swap the string table back for the previous function.
   strings_by_offset_.swap(temp_strings_by_offset);

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -21,7 +21,7 @@ class Parser;
 
 class BinAstDeserializer {
  public:
-  BinAstDeserializer(Isolate* isolate, Parser* parser, Handle<ByteArray> parse_data);
+  BinAstDeserializer(Isolate* isolate, Parser* parser, Handle<ByteArray> parse_data, MaybeHandle<PreparseData> preparse_data);
 
   AstNode* DeserializeAst(base::Optional<uint32_t> start_offset = base::nullopt,
                           base::Optional<uint32_t> length = base::nullopt);
@@ -42,6 +42,8 @@ class BinAstDeserializer {
                                       base::Optional<uint32_t> length,
                                       uint8_t* uncompressed_ast,
                                       size_t uncompressed_size);
+
+  void ConsumePreparseData();
 
   DeserializeResult<AstNode*> DeserializeMaybeAstNode(uint8_t* serialized_binast, int offset);
 
@@ -78,12 +80,13 @@ class BinAstDeserializer {
   DeserializeResult<Variable*> DeserializeScopeVariableOrReference(uint8_t* serialized_binast, int offset, Scope* scope);
   DeserializeResult<Variable*> DeserializeNonScopeVariableOrReference(uint8_t* serialized_binast, int offset);
   DeserializeResult<std::nullptr_t> DeserializeScopeVariableMap(uint8_t* serialized_binast, int offset, Scope* scope);
+  DeserializeResult<std::nullptr_t> DeserializeScopeUnresolvedList(uint8_t* serialized_binast, int offset, Scope* scope);
   DeserializeResult<Declaration*> DeserializeDeclaration(uint8_t* serialized_binast, int offset, Scope* scope);
   DeserializeResult<std::nullptr_t> DeserializeScopeDeclarations(uint8_t* serialized_binast, int offset, Scope* scope);
   DeserializeResult<std::nullptr_t> DeserializeScopeParameters(uint8_t* serialized_binast, int offset, DeclarationScope* scope);
   DeserializeResult<std::nullptr_t> DeserializeCommonScopeFields(uint8_t* serialized_binast, int offset, Scope* scope);
   DeserializeResult<Scope*> DeserializeScope(uint8_t* serialized_binast, int offset);
-  DeserializeResult<DeclarationScope*> DeserializeDeclarationScope(uint8_t* serialized_binast, int offset);
+  DeserializeResult<DeclarationScope*> DeserializeDeclarationScope(uint8_t* serialized_binast, int offset, bool can_skip_function);
 
   DeserializeResult<AstNode*> DeserializeAstNode(uint8_t* serialized_ast, int offset, bool is_toplevel = false);
   DeserializeResult<FunctionLiteral*> DeserializeFunctionLiteral(uint8_t* serialized_ast, uint32_t bit_field, int32_t position, int offset);
@@ -91,7 +94,7 @@ class BinAstDeserializer {
   DeserializeResult<BinaryOperation*> DeserializeBinaryOperation(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<Property*> DeserializeProperty(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<ExpressionStatement*> DeserializeExpressionStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
-  DeserializeResult<VariableProxy*> DeserializeVariableProxy(uint8_t* serialized_binast, int offset);
+  DeserializeResult<VariableProxy*> DeserializeVariableProxy(uint8_t* serialized_binast, int offset, bool add_unresolved = true);
   DeserializeResult<VariableProxyExpression*> DeserializeVariableProxyExpression(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<Literal*> DeserializeLiteral(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<Call*> DeserializeCall(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
@@ -124,10 +127,13 @@ class BinAstDeserializer {
   Isolate* isolate_;
   Parser* parser_;
   Handle<ByteArray> parse_data_;
+  MaybeHandle<PreparseData> preparse_data_;
   std::unordered_map<uint32_t, const AstRawString*> strings_by_offset_;
   std::unordered_map<uint32_t, Variable*> variables_by_id_;
   std::unordered_map<uint32_t, AstNode*> nodes_by_offset_;
   std::unordered_map<uint32_t, std::vector<void**>> patchable_fields_by_offset_;
+  std::unordered_map<int, ProducedPreparseData*> produced_preparse_data_by_offset_;
+  bool is_root_fn_;
 };
 
 }  // namespace internal

--- a/src/parsing/preparse-data.h
+++ b/src/parsing/preparse-data.h
@@ -300,6 +300,12 @@ class ConsumedPreparseData {
       int* function_length, int* num_inner_functions, bool* uses_super_property,
       LanguageMode* language_mode) = 0;
 
+  virtual bool IsFunctionOffsetNextSkippable(int start_position) = 0;
+  virtual int NextSkippableFunctionOffset() = 0;
+
+
+  virtual void ResetIndex() = 0;
+
   // Restores the information needed for allocating the Scope's (and its
   // subscopes') variables.
   virtual void RestoreScopeAllocationData(DeclarationScope* scope,

--- a/src/runtime/runtime-scopes.cc
+++ b/src/runtime/runtime-scopes.cc
@@ -198,6 +198,7 @@ RUNTIME_FUNCTION(Runtime_DeclareGlobals) {
 
     if (is_var) {
       name = Handle<String>::cast(decl);
+      // printf("Declaring a global var '%s'\n", name->ToCString().get());
       value = isolate->factory()->undefined_value();
     } else {
       Handle<SharedFunctionInfo> sfi = Handle<SharedFunctionInfo>::cast(decl);


### PR DESCRIPTION
This diff enables skipping inner functions during AST deserialization by
re-using the PreparseData generated by the lazy parser, which already
contains the relevant scope information needed to properly allocate
captured variables.