### PR TITLE
Fix de/serialization for ObjectLiteral and TryCatchStatement

### DIFF
--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -963,6 +963,7 @@ inline void BinAstSerializeVisitor::VisitObjectLiteral(ObjectLiteral* object_lit
   SerializeAstNodeHeader(object_literal);
 
   SerializeInt32(object_literal->properties()->length());
+  SerializeInt32(object_literal->properties_count()); // i.e. boilerplate_properties
 
   for (int i = 0; i < object_literal->properties()->length(); i++) {
     auto property = object_literal->properties()->at(i);
@@ -1018,7 +1019,12 @@ inline void BinAstSerializeVisitor::VisitTryCatchStatement(
     TryCatchStatement* try_catch_statement) {
   SerializeAstNodeHeader(try_catch_statement);
   VisitNode(try_catch_statement->try_block());
-  SerializeScope(try_catch_statement->scope());
+  if (try_catch_statement->scope()) {
+    SerializeUint8(1);
+    SerializeScope(try_catch_statement->scope());
+  } else {
+    SerializeUint8(0);
+  }
   VisitNode(try_catch_statement->catch_block());
 }
 


### PR DESCRIPTION
These two bugs were encountered while browsing around the web.
We were trying to re-compute how many boilerplate properties a particular
ObjectLiteral had upon deserialization instead of just storing the field
in the serialization format. Doing the latter fixed the crash. We also
were not behaving correctly in the absence of a Scope when serializing
a TryCatchStatement, which we now mark correctly.