### PR TITLE
Make string metadata fixed size to speed up deserialization

### DIFF
--- a/src/parsing/abstract-parser.h
+++ b/src/parsing/abstract-parser.h
@@ -2052,7 +2052,7 @@ void AbstractParser<Impl>::ParseFunction(
       deserialize_microseconds =
         std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
       int function_length = result->end_position() - result->start_position();
-      printf("PREPARSE++: Deserialize time for %sfunction (%d bytes) in %lld us", is_inner_binast ? "inner " : "", function_length, deserialize_microseconds);
+      printf("PREPARSE++: Deserialize time for %sfunction (%d bytes) in %lld us\n", is_inner_binast ? "inner " : "", function_length, deserialize_microseconds);
     }
   }
 

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -124,10 +124,11 @@ class BinAstDeserializer {
   Isolate* isolate_;
   Parser* parser_;
   Handle<ByteArray> parse_data_;
-  std::unordered_map<uint32_t, const AstRawString*> strings_by_offset_;
+  std::vector<const AstRawString*> strings_;
   std::unordered_map<uint32_t, Variable*> variables_by_id_;
   std::unordered_map<uint32_t, AstNode*> nodes_by_offset_;
   std::unordered_map<uint32_t, std::vector<void**>> patchable_fields_by_offset_;
+  uint32_t string_table_base_offset_;
 };
 
 }  // namespace internal


### PR DESCRIPTION
Prior to this diff the strings in the global string table were variable
size due to storing their contents inline. To avoid having to deserialize
all raw strings within a function family, we maintained a proxy string table
for each function that served as a forwarding pointer to the offset in the
global string table for each string used within that function. During
deserialization we needed to construct this map for lookups, which ended
up being expensive in deserialization microbenchmarks.

To make these lookups cheaper and to avoid having to allocate this hash map,
this diff stores the string header and contents separately. This enables the
function-local proxy strings to store an index into the global string table
rather than a global offset. Now during deserialization we construct a small
vector of raw strings for just the strings referenced within this function
and index into it.