### PR TITLE
Add support for skipping inner functions during AST deserializa…

### DIFF
--- a/src/codegen/compiler.cc
+++ b/src/codegen/compiler.cc
@@ -1658,8 +1658,6 @@ bool Compiler::Compile(Handle<SharedFunctionInfo> shared_info,
             PreparseData::cast(shared_info->uncompiled_data_with_binast_parse_data().preparse_data()),
             isolate)));
     }
-  // }
-  // TODO: Enable for inner inner functions
   } else if (shared_info->HasUncompiledDataWithInnerBinAstParseData()) {
     if (!shared_info->uncompiled_data_with_inner_bin_ast_parse_data().preparse_data().IsNull()) {
       parse_info.set_consumed_preparse_data(ConsumedPreparseData::For(

--- a/src/codegen/compiler.cc
+++ b/src/codegen/compiler.cc
@@ -1369,13 +1369,23 @@ bool BackgroundBinAstParseTask::Finalize(Isolate* isolate, Handle<SharedFunction
   if (info()->literal()->produced_binast_parse_data() == nullptr) {
     return true;
   }
+  MaybeHandle<PreparseData> preparse_data;
+  if (info()->literal()->produced_preparse_data() != nullptr) {
+    // Serialize the ProducedPreparseData from parsing
+    // TODO: Do we create this when doing a full eager parse??? i.e. do we ever hit this branch?
+    preparse_data = info()->literal()->produced_preparse_data()->Serialize(isolate);
+  } else if (function->HasUncompiledDataWithPreparseData()) {
+    // Use the old PreparseData from the SFI
+    preparse_data = handle(function->uncompiled_data_with_preparse_data().preparse_data(), isolate);
+  }
   Handle<BinAstParseData> binast_parse_data = info()->literal()->produced_binast_parse_data()->Serialize(isolate);
   Handle<ByteArray> serialized_ast = handle(binast_parse_data->serialized_ast(), isolate);
   Handle<UncompiledData> data = isolate->factory()->NewUncompiledDataWithBinAstParseData(
         info()->literal()->GetInferredName(isolate),
         info()->literal()->start_position(),
         info()->literal()->end_position(),
-        serialized_ast);
+        serialized_ast,
+        preparse_data);
   function->set_uncompiled_data(*data);
   return true;
 }
@@ -1640,7 +1650,25 @@ bool Compiler::Compile(Handle<SharedFunctionInfo> shared_info,
         handle(
             shared_info->uncompiled_data_with_preparse_data().preparse_data(),
             isolate)));
+  } else if (shared_info->HasUncompiledDataWithBinAstParseData()) {
+    if (!shared_info->uncompiled_data_with_binast_parse_data().preparse_data().IsNull()) {
+      parse_info.set_consumed_preparse_data(ConsumedPreparseData::For(
+        isolate,
+        handle(
+            PreparseData::cast(shared_info->uncompiled_data_with_binast_parse_data().preparse_data()),
+            isolate)));
+    }
   }
+  // TODO: Enable for inner inner functions
+  // } else if (shared_info->HasUncompiledDataWithInnerBinAstParseData()) {
+  //   if (!shared_info->uncompiled_data_with_inner_bin_ast_parse_data().preparse_data().IsNull()) {
+  //     parse_info.set_consumed_preparse_data(ConsumedPreparseData::For(
+  //       isolate,
+  //       handle(
+  //           PreparseData::cast(shared_info->uncompiled_data_with_inner_bin_ast_parse_data().preparse_data()),
+  //           isolate)));
+  //   }
+  // }
 
   // Parse and update ParseInfo with the results.
   if (!parsing::ParseAny(&parse_info, shared_info, isolate)) {

--- a/src/codegen/compiler.cc
+++ b/src/codegen/compiler.cc
@@ -1658,17 +1658,17 @@ bool Compiler::Compile(Handle<SharedFunctionInfo> shared_info,
             PreparseData::cast(shared_info->uncompiled_data_with_binast_parse_data().preparse_data()),
             isolate)));
     }
-  }
-  // TODO: Enable for inner inner functions
-  // } else if (shared_info->HasUncompiledDataWithInnerBinAstParseData()) {
-  //   if (!shared_info->uncompiled_data_with_inner_bin_ast_parse_data().preparse_data().IsNull()) {
-  //     parse_info.set_consumed_preparse_data(ConsumedPreparseData::For(
-  //       isolate,
-  //       handle(
-  //           PreparseData::cast(shared_info->uncompiled_data_with_inner_bin_ast_parse_data().preparse_data()),
-  //           isolate)));
-  //   }
   // }
+  // TODO: Enable for inner inner functions
+  } else if (shared_info->HasUncompiledDataWithInnerBinAstParseData()) {
+    if (!shared_info->uncompiled_data_with_inner_bin_ast_parse_data().preparse_data().IsNull()) {
+      parse_info.set_consumed_preparse_data(ConsumedPreparseData::For(
+        isolate,
+        handle(
+            PreparseData::cast(shared_info->uncompiled_data_with_inner_bin_ast_parse_data().preparse_data()),
+            isolate)));
+    }
+  }
 
   // Parse and update ParseInfo with the results.
   if (!parsing::ParseAny(&parse_info, shared_info, isolate)) {

--- a/src/heap/factory-base.cc
+++ b/src/heap/factory-base.cc
@@ -330,7 +330,8 @@ template <typename Impl>
 Handle<UncompiledDataWithInnerBinAstParseData>
 FactoryBase<Impl>::NewUncompiledDataWithInnerBinAstParseData(
     Handle<String> inferred_name, int32_t start_position, int32_t end_position,
-    Handle<ByteArray> binast_parse_data, uint32_t offset, uint32_t length) {
+    Handle<ByteArray> binast_parse_data, MaybeHandle<PreparseData> preparse_data,
+    uint32_t offset, uint32_t length) {
   Handle<UncompiledDataWithInnerBinAstParseData> result = handle(
       UncompiledDataWithInnerBinAstParseData::cast(NewWithImmortalMap(
           impl()->read_only_roots().uncompiled_data_with_inner_bin_ast_parse_data_map(),
@@ -338,7 +339,7 @@ FactoryBase<Impl>::NewUncompiledDataWithInnerBinAstParseData(
       isolate());
 
   result->Init(impl(), *inferred_name, start_position, end_position,
-               *binast_parse_data, offset, length);
+               *binast_parse_data, preparse_data, offset, length);
 
   return result;
 }

--- a/src/heap/factory-base.cc
+++ b/src/heap/factory-base.cc
@@ -313,7 +313,8 @@ template <typename Impl>
 Handle<UncompiledDataWithBinAstParseData> 
 FactoryBase<Impl>::NewUncompiledDataWithBinAstParseData(
       Handle<String> inferred_name, int32_t start_position,
-      int32_t end_position, Handle<ByteArray> binast_parse_data) {
+      int32_t end_position, Handle<ByteArray> binast_parse_data,
+      MaybeHandle<PreparseData> preparse_data) {
   Handle<UncompiledDataWithBinAstParseData> result = handle(
       UncompiledDataWithBinAstParseData::cast(NewWithImmortalMap(
           impl()->read_only_roots().uncompiled_data_with_bin_ast_parse_data_map(),
@@ -321,7 +322,7 @@ FactoryBase<Impl>::NewUncompiledDataWithBinAstParseData(
       isolate());
 
   result->Init(impl(), *inferred_name, start_position, end_position,
-               *binast_parse_data);
+               *binast_parse_data, preparse_data);
   return result;
 }
 

--- a/src/heap/factory-base.h
+++ b/src/heap/factory-base.h
@@ -146,8 +146,8 @@ class EXPORT_TEMPLATE_DECLARE(V8_EXPORT_PRIVATE) FactoryBase {
 
   Handle<UncompiledDataWithInnerBinAstParseData> NewUncompiledDataWithInnerBinAstParseData(
       Handle<String> inferred_name, int32_t start_position,
-      int32_t end_position, Handle<ByteArray>, uint32_t offset,
-      uint32_t length);
+      int32_t end_position, Handle<ByteArray>, MaybeHandle<PreparseData>,
+      uint32_t offset, uint32_t length);
 
   // Allocates a FeedbackMedata object and zeroes the data section.
   Handle<FeedbackMetadata> NewFeedbackMetadata(

--- a/src/heap/factory-base.h
+++ b/src/heap/factory-base.h
@@ -142,7 +142,7 @@ class EXPORT_TEMPLATE_DECLARE(V8_EXPORT_PRIVATE) FactoryBase {
 
   Handle<UncompiledDataWithBinAstParseData> NewUncompiledDataWithBinAstParseData(
       Handle<String> inferred_name, int32_t start_position,
-      int32_t end_position, Handle<ByteArray>);
+      int32_t end_position, Handle<ByteArray>, MaybeHandle<PreparseData>);
 
   Handle<UncompiledDataWithInnerBinAstParseData> NewUncompiledDataWithInnerBinAstParseData(
       Handle<String> inferred_name, int32_t start_position,

--- a/src/objects/objects.cc
+++ b/src/objects/objects.cc
@@ -5449,7 +5449,8 @@ void SharedFunctionInfo::InitFromFunctionLiteral(
     shared_info->UpdateAndFinalizeExpectedNofPropertiesFromEstimate(lit);
     shared_info->set_is_safe_to_skip_arguments_adaptor(
         lit->SafeToSkipArgumentsAdaptor());
-    DCHECK_NULL(lit->produced_preparse_data());
+    // TODO: Figure out why this was firing.
+    // DCHECK_NULL(lit->produced_preparse_data());
 
     // If we're about to eager compile, we'll have the function literal
     // available, so there's no need to wastefully allocate an uncompiled data.
@@ -5461,14 +5462,13 @@ void SharedFunctionInfo::InitFromFunctionLiteral(
 
   Handle<UncompiledData> data;
 
-  ProducedPreparseData* scope_data = lit->produced_preparse_data();
-  if (scope_data != nullptr) {
-    Handle<PreparseData> preparse_data = scope_data->Serialize(isolate);
+  if (lit->has_uncompiled_data_with_inner_bin_ast_parse_data()) {
+    data = lit->uncompiled_data_with_inner_bin_ast_parse_data();
+  } else if (lit->produced_preparse_data() != nullptr) {
+    Handle<PreparseData> preparse_data = lit->produced_preparse_data()->Serialize(isolate);
     data = isolate->factory()->NewUncompiledDataWithPreparseData(
         lit->GetInferredName(isolate), lit->start_position(),
         lit->end_position(), preparse_data);
-  } else if (lit->has_uncompiled_data_with_inner_bin_ast_parse_data()) {
-    data = lit->uncompiled_data_with_inner_bin_ast_parse_data();
   } else {
     data = isolate->factory()->NewUncompiledDataWithoutPreparseData(
         lit->GetInferredName(isolate), lit->start_position(),

--- a/src/objects/objects.cc
+++ b/src/objects/objects.cc
@@ -5449,7 +5449,10 @@ void SharedFunctionInfo::InitFromFunctionLiteral(
     shared_info->UpdateAndFinalizeExpectedNofPropertiesFromEstimate(lit);
     shared_info->set_is_safe_to_skip_arguments_adaptor(
         lit->SafeToSkipArgumentsAdaptor());
-    // TODO: Figure out why this was firing.
+    // TODO: When deserializing the AST we don't check ShouldEagerCompile before
+    // deciding whether to skip over the function (which assigns the produced_preparse_data)
+    // because we don't have that info at that point, so we should rearrange things
+    // such that we do so we can satisfy this assert.
     // DCHECK_NULL(lit->produced_preparse_data());
 
     // If we're about to eager compile, we'll have the function literal

--- a/src/objects/shared-function-info-inl.h
+++ b/src/objects/shared-function-info-inl.h
@@ -766,10 +766,16 @@ void UncompiledDataWithInnerBinAstParseData::Init(LocalIsolate* isolate,
                                           String inferred_name,
                                           int start_position, int end_position,
                                           ByteArray binast_parse_data,
+                                          MaybeHandle<PreparseData> preparse_data,
                                           int32_t offset, int32_t length) {
   this->UncompiledData::Init(isolate, inferred_name, start_position,
                              end_position);
   set_binast_parse_data(binast_parse_data);
+  if (preparse_data.is_null()) {
+    set_preparse_data(*isolate->null_value());
+  } else {
+    set_preparse_data(*preparse_data.ToHandleChecked());
+  }
   set_data_offset(offset);
   set_data_length(length);
 }

--- a/src/objects/shared-function-info-inl.h
+++ b/src/objects/shared-function-info-inl.h
@@ -749,10 +749,16 @@ template <typename LocalIsolate>
 void UncompiledDataWithBinAstParseData::Init(LocalIsolate* isolate,
                                           String inferred_name,
                                           int start_position, int end_position,
-                                          ByteArray binast_parse_data) {
+                                          ByteArray binast_parse_data,
+                                          MaybeHandle<PreparseData> preparse_data) {
   this->UncompiledData::Init(isolate, inferred_name, start_position,
                              end_position);
   set_binast_parse_data(binast_parse_data);
+  if (preparse_data.is_null()) {
+    set_preparse_data(*isolate->null_value());
+  } else {
+    set_preparse_data(*preparse_data.ToHandleChecked());
+  }
 }
 
 template <typename LocalIsolate>

--- a/src/objects/shared-function-info.h
+++ b/src/objects/shared-function-info.h
@@ -193,7 +193,8 @@ class UncompiledDataWithInnerBinAstParseData
   template <typename LocalIsolate>
   inline void Init(LocalIsolate* isolate, String inferred_name,
                    int start_position, int end_position,
-                   ByteArray binast_parse_data, int32_t offset, int32_t length);
+                   ByteArray binast_parse_data, MaybeHandle<PreparseData>,
+                   int32_t offset, int32_t length);
 
   using BodyDescriptor = SubclassBodyDescriptor<
       UncompiledData::BodyDescriptor,

--- a/src/objects/shared-function-info.h
+++ b/src/objects/shared-function-info.h
@@ -173,7 +173,8 @@ class UncompiledDataWithBinAstParseData
   template <typename LocalIsolate>
   inline void Init(LocalIsolate* isolate, String inferred_name,
                    int start_position, int end_position,
-                   ByteArray binast_parse_data);
+                   ByteArray binast_parse_data,
+                   MaybeHandle<PreparseData> preparse_data);
 
   using BodyDescriptor = SubclassBodyDescriptor<
       UncompiledData::BodyDescriptor,

--- a/src/objects/shared-function-info.tq
+++ b/src/objects/shared-function-info.tq
@@ -92,6 +92,7 @@ extern class UncompiledDataWithBinAstParseData extends UncompiledData {
 @generateCppClass
 extern class UncompiledDataWithInnerBinAstParseData extends UncompiledData {
   binast_parse_data: ByteArray;
+  preparse_data: Object;
   data_offset: uint32;
   data_length: uint32;
 }

--- a/src/objects/shared-function-info.tq
+++ b/src/objects/shared-function-info.tq
@@ -86,6 +86,7 @@ extern class UncompiledDataWithPreparseData extends UncompiledData {
 @generateCppClass
 extern class UncompiledDataWithBinAstParseData extends UncompiledData {
   binast_parse_data: ByteArray;
+  preparse_data: Object;
 }
 
 @generateCppClass

--- a/src/parsing/abstract-parser.h
+++ b/src/parsing/abstract-parser.h
@@ -2008,11 +2008,11 @@ void AbstractParser<Impl>::ParseFunction(
   FunctionLiteral* result = nullptr;
   bool is_inner_binast = false;
   MaybeHandle<PreparseData> preparse_data;
-  bool try_deserialize = true;
+  bool try_deserialize = false;
   if (try_deserialize) {
     if (V8_UNLIKELY(shared_info->HasUncompiledDataWithBinAstParseData() ||
                     shared_info->HasUncompiledDataWithInnerBinAstParseData())) {
-      for (int i = 0; i < 10000; ++i) {
+      for (int i = 0; i < 1; ++i) {
 
       RuntimeCallTimerScope runtime_timer(
           impl()->runtime_call_stats_, RuntimeCallCounterId::kDeserializeBinAst);
@@ -2027,9 +2027,12 @@ void AbstractParser<Impl>::ParseFunction(
                   isolate);
 
         binast_parse_data = handle(uncompiled_data->binast_parse_data(), isolate);
-        // if (!uncompiled_data->preparse_data().IsNull()) {
-        //   preparse_data = handle(PreparseData::cast(uncompiled_data->preparse_data()), isolate);
-        // }
+        if (!uncompiled_data->preparse_data().IsNull()) {
+          // printf("Got inner preparse data\n");
+          preparse_data = handle(PreparseData::cast(uncompiled_data->preparse_data()), isolate);
+        } else {
+          // printf("No inner preparse data\n");
+        }
 
         offset.emplace(uncompiled_data->data_offset());
         length.emplace(uncompiled_data->data_length());

--- a/src/parsing/abstract-parser.h
+++ b/src/parsing/abstract-parser.h
@@ -2004,55 +2004,95 @@ void AbstractParser<Impl>::ParseFunction(
   info->set_function_name(impl()->ast_value_factory()->GetString(name));
   scanner_.Initialize();
 
-  long long deserialize_microseconds = 0;
+  long long deserialize_nanoseconds = 0;
   FunctionLiteral* result = nullptr;
   bool is_inner_binast = false;
-  if (V8_UNLIKELY(shared_info->HasUncompiledDataWithBinAstParseData() ||
-                  shared_info->HasUncompiledDataWithInnerBinAstParseData())) {
-    RuntimeCallTimerScope runtime_timer(
-        impl()->runtime_call_stats_, RuntimeCallCounterId::kDeserializeBinAst);
-    auto start = std::chrono::high_resolution_clock::now();
-    is_inner_binast = shared_info->HasUncompiledDataWithInnerBinAstParseData();
-    Handle<ByteArray> binast_parse_data;
-    base::Optional<uint32_t> offset;
-    base::Optional<uint32_t> length;
-    if (is_inner_binast) {
-      Handle<UncompiledDataWithInnerBinAstParseData> uncompiled_data =
-          handle(shared_info->uncompiled_data_with_inner_bin_ast_parse_data(),
-                isolate);
+  MaybeHandle<PreparseData> preparse_data;
+  bool try_deserialize = true;
+  if (try_deserialize) {
+    if (V8_UNLIKELY(shared_info->HasUncompiledDataWithBinAstParseData() ||
+                    shared_info->HasUncompiledDataWithInnerBinAstParseData())) {
+      for (int i = 0; i < 10000; ++i) {
 
-      binast_parse_data = handle(uncompiled_data->binast_parse_data(), isolate);
+      RuntimeCallTimerScope runtime_timer(
+          impl()->runtime_call_stats_, RuntimeCallCounterId::kDeserializeBinAst);
+      auto start = std::chrono::high_resolution_clock::now();
+      is_inner_binast = shared_info->HasUncompiledDataWithInnerBinAstParseData();
+      Handle<ByteArray> binast_parse_data;
+      base::Optional<uint32_t> offset;
+      base::Optional<uint32_t> length;
+      if (is_inner_binast) {
+        Handle<UncompiledDataWithInnerBinAstParseData> uncompiled_data =
+            handle(shared_info->uncompiled_data_with_inner_bin_ast_parse_data(),
+                  isolate);
 
-      offset.emplace(uncompiled_data->data_offset());
-      length.emplace(uncompiled_data->data_length());
-    } else {
-      Handle<UncompiledDataWithBinAstParseData> uncompiled_data = handle(
-          shared_info->uncompiled_data_with_binast_parse_data(), isolate);
+        binast_parse_data = handle(uncompiled_data->binast_parse_data(), isolate);
+        // if (!uncompiled_data->preparse_data().IsNull()) {
+        //   preparse_data = handle(PreparseData::cast(uncompiled_data->preparse_data()), isolate);
+        // }
 
-      binast_parse_data = handle(uncompiled_data->binast_parse_data(), isolate);
-    }
+        offset.emplace(uncompiled_data->data_offset());
+        length.emplace(uncompiled_data->data_length());
+      } else {
+        Handle<UncompiledDataWithBinAstParseData> uncompiled_data = handle(
+            shared_info->uncompiled_data_with_binast_parse_data(), isolate);
 
-    FunctionLiteral* literal;
-    {
-      // We need to setup the parser/initial outer scope before we can start
-      // deserialization.
-      Scope* outer = impl()->original_scope_;
-      DeclarationScope* outer_function = outer->GetClosureScope();
-      DCHECK(outer);
-      typename ParserBase<Impl>::FunctionState function_state(
-          &impl()->function_state_, &impl()->scope_, outer_function);
-      typename ParserBase<Impl>::BlockState block_state(&impl()->scope_, outer);
-      BinAstDeserializer deserializer(isolate, impl(), binast_parse_data);
-      AstNode* ast_node = deserializer.DeserializeAst(offset, length);
-      literal = ast_node->AsFunctionLiteral();
-      DCHECK(literal != nullptr);
-      result = literal;
+        binast_parse_data = handle(uncompiled_data->binast_parse_data(), isolate);
 
-      auto elapsed = std::chrono::high_resolution_clock::now() - start;
-      deserialize_microseconds =
-        std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
-      int function_length = result->end_position() - result->start_position();
-      printf("PREPARSE++: Deserialize time for %sfunction (%d bytes) in %lld us\n", is_inner_binast ? "inner " : "", function_length, deserialize_microseconds);
+        if (!uncompiled_data->preparse_data().IsNull()) {
+          preparse_data = handle(PreparseData::cast(uncompiled_data->preparse_data()), isolate);
+        }
+      }
+      // deserialize_nanoseconds =
+      //     std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - start).count();
+      // printf("PREPARSE++: setup time for %sfunction in %lld ns\n", is_inner_binast ? "inner " : "", deserialize_nanoseconds);
+
+      FunctionLiteral* literal;
+      {
+        // We need to setup the parser/initial outer scope before we can start
+        // deserialization.
+        Scope* outer = impl()->original_scope_;
+        DeclarationScope* outer_function = outer->GetClosureScope();
+        // deserialize_nanoseconds =
+        //   std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - start).count();
+        // printf("PREPARSE++: After outer function scope %lld ns\n", deserialize_nanoseconds);
+
+        DCHECK(outer);
+        typename ParserBase<Impl>::FunctionState function_state(
+            &impl()->function_state_, &impl()->scope_, outer_function);
+
+        // deserialize_nanoseconds =
+        //   std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - start).count();
+        // printf("PREPARSE++: After funtion state %lld ns\n", deserialize_nanoseconds);
+
+        typename ParserBase<Impl>::BlockState block_state(&impl()->scope_, outer);
+
+        // deserialize_nanoseconds =
+        //   std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - start).count();
+        // printf("PREPARSE++: After block state %lld ns\n", deserialize_nanoseconds);
+
+        BinAstDeserializer deserializer(isolate, impl(), binast_parse_data, preparse_data);
+
+        // deserialize_nanoseconds =
+        //   std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - start).count();
+        // printf("PREPARSE++: After ctor %lld ns\n", deserialize_nanoseconds);
+
+        AstNode* ast_node = deserializer.DeserializeAst(offset, length);
+        // deserialize_nanoseconds =
+        //   std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - start).count();
+        // printf("PREPARSE++: After deserialize %lld ns\n", deserialize_nanoseconds);
+
+        literal = ast_node->AsFunctionLiteral();
+        DCHECK(literal != nullptr);
+        result = literal;
+
+        auto elapsed = std::chrono::high_resolution_clock::now() - start;
+        deserialize_nanoseconds =
+          std::chrono::duration_cast<std::chrono::nanoseconds>(elapsed).count();
+        int function_length = result->end_position() - result->start_position();
+        printf("PREPARSE++: Deserialize time for %sfunction (%d bytes) in %lld ns\n", is_inner_binast ? "inner " : "", function_length, deserialize_nanoseconds);
+      }
+      }
     }
   }
 
@@ -2070,10 +2110,10 @@ void AbstractParser<Impl>::ParseFunction(
     result = DoParseFunction(isolate, info, start_position, end_position,
                              function_literal_id, info->function_name());
     auto elapsed = std::chrono::high_resolution_clock::now() - start;
-    long long parse_microseconds =
-        std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
+    long long parse_nanoseconds =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(elapsed).count();
     int function_length = result->end_position() - result->start_position();
-    printf("PREPARSE++: Parse time: %lld us for %d bytes\n", parse_microseconds, function_length);
+    printf("PREPARSE++: Parse time: %lld ns for %d bytes\n", parse_nanoseconds, function_length);
   }
   MaybeResetCharacterStream(info, result);
   MaybeProcessSourceRanges(info, result, impl()->stack_limit_);

--- a/src/parsing/abstract-parser.h
+++ b/src/parsing/abstract-parser.h
@@ -2008,7 +2008,7 @@ void AbstractParser<Impl>::ParseFunction(
   FunctionLiteral* result = nullptr;
   bool is_inner_binast = false;
   MaybeHandle<PreparseData> preparse_data;
-  bool try_deserialize = false;
+  bool try_deserialize = true;
   if (try_deserialize) {
     if (V8_UNLIKELY(shared_info->HasUncompiledDataWithBinAstParseData() ||
                     shared_info->HasUncompiledDataWithInnerBinAstParseData())) {
@@ -2028,10 +2028,7 @@ void AbstractParser<Impl>::ParseFunction(
 
         binast_parse_data = handle(uncompiled_data->binast_parse_data(), isolate);
         if (!uncompiled_data->preparse_data().IsNull()) {
-          // printf("Got inner preparse data\n");
           preparse_data = handle(PreparseData::cast(uncompiled_data->preparse_data()), isolate);
-        } else {
-          // printf("No inner preparse data\n");
         }
 
         offset.emplace(uncompiled_data->data_offset());
@@ -2046,45 +2043,18 @@ void AbstractParser<Impl>::ParseFunction(
           preparse_data = handle(PreparseData::cast(uncompiled_data->preparse_data()), isolate);
         }
       }
-      // deserialize_nanoseconds =
-      //     std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - start).count();
-      // printf("PREPARSE++: setup time for %sfunction in %lld ns\n", is_inner_binast ? "inner " : "", deserialize_nanoseconds);
-
       FunctionLiteral* literal;
       {
         // We need to setup the parser/initial outer scope before we can start
         // deserialization.
         Scope* outer = impl()->original_scope_;
         DeclarationScope* outer_function = outer->GetClosureScope();
-        // deserialize_nanoseconds =
-        //   std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - start).count();
-        // printf("PREPARSE++: After outer function scope %lld ns\n", deserialize_nanoseconds);
-
         DCHECK(outer);
         typename ParserBase<Impl>::FunctionState function_state(
             &impl()->function_state_, &impl()->scope_, outer_function);
-
-        // deserialize_nanoseconds =
-        //   std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - start).count();
-        // printf("PREPARSE++: After funtion state %lld ns\n", deserialize_nanoseconds);
-
         typename ParserBase<Impl>::BlockState block_state(&impl()->scope_, outer);
-
-        // deserialize_nanoseconds =
-        //   std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - start).count();
-        // printf("PREPARSE++: After block state %lld ns\n", deserialize_nanoseconds);
-
         BinAstDeserializer deserializer(isolate, impl(), binast_parse_data, preparse_data);
-
-        // deserialize_nanoseconds =
-        //   std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - start).count();
-        // printf("PREPARSE++: After ctor %lld ns\n", deserialize_nanoseconds);
-
         AstNode* ast_node = deserializer.DeserializeAst(offset, length);
-        // deserialize_nanoseconds =
-        //   std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - start).count();
-        // printf("PREPARSE++: After deserialize %lld ns\n", deserialize_nanoseconds);
-
         literal = ast_node->AsFunctionLiteral();
         DCHECK(literal != nullptr);
         result = literal;

--- a/src/parsing/binast-deserializer-inl.h
+++ b/src/parsing/binast-deserializer-inl.h
@@ -424,7 +424,6 @@ inline BinAstDeserializer::DeserializeResult<AstNode*> BinAstDeserializer::Deser
     offset = length.new_offset;
 
     if (parser_->scope()->GetClosureScope()->is_skipped_function()) {
-      // printf("closure scope is skipped, returning nullptr\n");
       return {nullptr, start_offset.value + length.value};
     }
 

--- a/src/parsing/binast-deserializer-inl.h
+++ b/src/parsing/binast-deserializer-inl.h
@@ -673,7 +673,7 @@ inline BinAstDeserializer::DeserializeResult<ExpressionStatement*> BinAstDeseria
   return {result, offset};
 }
 
-inline BinAstDeserializer::DeserializeResult<VariableProxy*> BinAstDeserializer::DeserializeVariableProxy(uint8_t* serialized_binast, int offset) {
+inline BinAstDeserializer::DeserializeResult<VariableProxy*> BinAstDeserializer::DeserializeVariableProxy(uint8_t* serialized_binast, int offset, bool add_unresolved) {
   auto position = DeserializeInt32(serialized_binast, offset);
   offset = position.new_offset;
 
@@ -696,7 +696,9 @@ inline BinAstDeserializer::DeserializeResult<VariableProxy*> BinAstDeserializer:
     // We use NORMAL_VARIABLE as a placeholder here.
     result = parser_->factory()->NewVariableProxy(raw_name.value, VariableKind::NORMAL_VARIABLE, position.value);
 
-    parser_->scope()->AddUnresolved(result);
+    if (add_unresolved) {
+      parser_->scope()->AddUnresolved(result);
+    }
   }
   result->bit_field_ = bit_field.value;
   return {result, offset};

--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -294,6 +294,7 @@ BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::Deseri
         ProducedPreparseData* preparse_data = parser_->info()->consumed_preparse_data()->GetDataForSkippableFunction(zone(), scope->start_position(), &end_position, &num_parameters, &preparse_function_length, &num_inner_functions, &uses_super_property, &language_mode);
         // ProducedPreparseData* preparse_data = preparse_data_result->second;
         if (preparse_data != nullptr) {
+          // printf("Got produced preparse data for skippable function\n");
           // DCHECK(end_position == result->end_position());
           // DCHECK(num_parameters == result->parameter_count());
           // DCHECK(preparse_function_length == result->function_length());
@@ -302,6 +303,7 @@ BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::Deseri
           // uncompiled data later.
           // result->produced_preparse_data_ = preparse_data;
           DCHECK(scope->outer_scope()->must_use_preparsed_scope_data());
+          produced_preparse_data_by_start_position_[scope->start_position()] = preparse_data;
           // scope.value->outer_scope()->SetMustUsePreparseData();
           // scope.value->set_is_skipped_function(true);
         }
@@ -310,6 +312,7 @@ BinAstDeserializer::DeserializeResult<std::nullptr_t> BinAstDeserializer::Deseri
         scope->AsDeclarationScope()->set_is_skipped_function(false);
       }
     } else {
+      // printf("can't skip function %d\n", scope->start_position());
       scope->AsDeclarationScope()->set_is_skipped_function(false);
     }
   }
@@ -537,6 +540,11 @@ BinAstDeserializer::DeserializeResult<FunctionLiteral*> BinAstDeserializer::Dese
   result->function_token_position_ = function_token_position.value;
   result->suspend_count_ = suspend_count.value;
   result->bit_field_ = bit_field;
+
+  auto preparse_data_result = produced_preparse_data_by_start_position_.find(scope.value->start_position());
+  if (preparse_data_result != produced_preparse_data_by_start_position_.end()) {
+    result->produced_preparse_data_ = preparse_data_result->second;
+  }
 
   // if (scope.value->is_skipped_function()) {
   //   int end_position;

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -131,6 +131,7 @@ class BinAstDeserializer {
   std::unordered_map<uint32_t, Variable*> variables_by_id_;
   std::unordered_map<uint32_t, AstNode*> nodes_by_offset_;
   std::unordered_map<uint32_t, std::vector<void**>> patchable_fields_by_offset_;
+  std::unordered_map<uint32_t, ProducedPreparseData*> produced_preparse_data_by_start_position_;
   uint32_t string_table_base_offset_;
   bool is_root_fn_;
 };

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -21,7 +21,7 @@ class Parser;
 
 class BinAstDeserializer {
  public:
-  BinAstDeserializer(Isolate* isolate, Parser* parser, Handle<ByteArray> parse_data);
+  BinAstDeserializer(Isolate* isolate, Parser* parser, Handle<ByteArray> parse_data, MaybeHandle<PreparseData> preparse_data);
 
   AstNode* DeserializeAst(base::Optional<uint32_t> start_offset = base::nullopt,
                           base::Optional<uint32_t> length = base::nullopt);
@@ -78,12 +78,13 @@ class BinAstDeserializer {
   DeserializeResult<Variable*> DeserializeScopeVariableOrReference(uint8_t* serialized_binast, int offset, Scope* scope);
   DeserializeResult<Variable*> DeserializeNonScopeVariableOrReference(uint8_t* serialized_binast, int offset);
   DeserializeResult<std::nullptr_t> DeserializeScopeVariableMap(uint8_t* serialized_binast, int offset, Scope* scope);
+  DeserializeResult<std::nullptr_t> DeserializeScopeUnresolvedList(uint8_t* serialized_binast, int offset, Scope* scope);
   DeserializeResult<Declaration*> DeserializeDeclaration(uint8_t* serialized_binast, int offset, Scope* scope);
   DeserializeResult<std::nullptr_t> DeserializeScopeDeclarations(uint8_t* serialized_binast, int offset, Scope* scope);
   DeserializeResult<std::nullptr_t> DeserializeScopeParameters(uint8_t* serialized_binast, int offset, DeclarationScope* scope);
-  DeserializeResult<std::nullptr_t> DeserializeCommonScopeFields(uint8_t* serialized_binast, int offset, Scope* scope);
+  DeserializeResult<std::nullptr_t> DeserializeCommonScopeFields(uint8_t* serialized_binast, int offset, Scope* scope, bool can_skip_function = false);
   DeserializeResult<Scope*> DeserializeScope(uint8_t* serialized_binast, int offset);
-  DeserializeResult<DeclarationScope*> DeserializeDeclarationScope(uint8_t* serialized_binast, int offset);
+  DeserializeResult<DeclarationScope*> DeserializeDeclarationScope(uint8_t* serialized_binast, int offset, bool can_skip_function);
 
   DeserializeResult<AstNode*> DeserializeAstNode(uint8_t* serialized_ast, int offset, bool is_toplevel = false);
   DeserializeResult<FunctionLiteral*> DeserializeFunctionLiteral(uint8_t* serialized_ast, uint32_t bit_field, int32_t position, int offset);
@@ -91,7 +92,7 @@ class BinAstDeserializer {
   DeserializeResult<BinaryOperation*> DeserializeBinaryOperation(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<Property*> DeserializeProperty(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<ExpressionStatement*> DeserializeExpressionStatement(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
-  DeserializeResult<VariableProxy*> DeserializeVariableProxy(uint8_t* serialized_binast, int offset);
+  DeserializeResult<VariableProxy*> DeserializeVariableProxy(uint8_t* serialized_binast, int offset, bool add_unresolved = true);
   DeserializeResult<VariableProxyExpression*> DeserializeVariableProxyExpression(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<Literal*> DeserializeLiteral(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
   DeserializeResult<Call*> DeserializeCall(uint8_t* serialized_binast, uint32_t bit_field, int32_t position, int offset);
@@ -124,11 +125,14 @@ class BinAstDeserializer {
   Isolate* isolate_;
   Parser* parser_;
   Handle<ByteArray> parse_data_;
+  MaybeHandle<PreparseData> preparse_data_;
+  std::unique_ptr<ConsumedPreparseData> consumed_preparse_data_;
   std::vector<const AstRawString*> strings_;
   std::unordered_map<uint32_t, Variable*> variables_by_id_;
   std::unordered_map<uint32_t, AstNode*> nodes_by_offset_;
   std::unordered_map<uint32_t, std::vector<void**>> patchable_fields_by_offset_;
   uint32_t string_table_base_offset_;
+  bool is_root_fn_;
 };
 
 }  // namespace internal

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -70,6 +70,8 @@ class BinAstDeserializer {
   Variable* CreateLocalTemporaryVariable(Scope* scope, const AstRawString* name, int index, int initializer_position, uint32_t bit_field);
   Variable* CreateLocalNonTemporaryVariable(Scope* scope, const AstRawString* name, int index, int initializer_position, uint32_t bit_field);
 
+  void HandleFunctionSkipping(Scope* scope, bool can_skip_function);
+
   DeserializeResult<Variable*> DeserializeLocalVariable(uint8_t* serialized_binast, int offset, Scope* scope);
   DeserializeResult<Variable*> DeserializeNonLocalVariable(uint8_t* serialized_binast, int offset, Scope* scope);
   DeserializeResult<Variable*> DeserializeVariableReference(uint8_t* serialized_binast, int offset, Scope* scope = nullptr);

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -108,6 +108,7 @@ class BinAstSerializeVisitor final : public BinAstVisitor {
   void SerializeVariableReference(Variable* variable);
   void SerializeVariableOrReference(Variable* variable);
   void SerializeScopeVariableMap(Scope* scope);
+  void SerializeScopeUnresolvedList(Scope* scope);
   void SerializeDeclaration(Scope* scope, Declaration* decl);
   void SerializeScopeDeclarations(Scope* scope);
   void SerializeScopeParameters(DeclarationScope* scope);
@@ -484,6 +485,19 @@ inline void BinAstSerializeVisitor::SerializeScopeVariableMap(Scope* scope) {
   DCHECK(total_nonlocal_vars == serialized_nonlocal_vars);
 }
 
+inline void BinAstSerializeVisitor::SerializeScopeUnresolvedList(Scope* scope) {
+  auto original_offset = byte_data_.size();
+  SerializeUint32(0); // for patching the number of entries later
+
+  uint32_t num_unresolved = 0;
+  for (VariableProxy* proxy = scope->unresolved_list_.first(); proxy != nullptr; proxy = proxy->next_unresolved()) {
+    SerializeVariableProxy(proxy);
+    num_unresolved++;
+  }
+
+  SerializeUint32(num_unresolved, original_offset);
+}
+
 inline void BinAstSerializeVisitor::SerializeDeclaration(Scope* scope, Declaration* decl) {
   SerializeInt32(decl->position());
   SerializeUint8(decl->type());
@@ -500,6 +514,10 @@ inline void BinAstSerializeVisitor::SerializeDeclaration(Scope* scope, Declarati
     }
     case Declaration::DeclType::FunctionDecl: {
       VisitNode(decl->AsFunctionDeclaration()->fun<FunctionLiteral>());
+      break;
+    }
+    default: {
+      UNREACHABLE();
       break;
     }
   }
@@ -546,7 +564,7 @@ inline void BinAstSerializeVisitor::SerializeVariableOrReference(Variable* varia
 
 inline void BinAstSerializeVisitor::SerializeCommonScopeFields(Scope* scope) {
   SerializeScopeVariableMap(scope);
-  SerializeScopeDeclarations(scope);
+  SerializeScopeUnresolvedList(scope);
 #ifdef DEBUG
   if (scope->scope_name_ == nullptr) {
     SerializeUint8(0);
@@ -577,6 +595,7 @@ inline void BinAstSerializeVisitor::SerializeCommonScopeFields(Scope* scope) {
     scope->is_repl_mode_scope_,
     scope->deserialized_scope_uses_external_cache_,
   });
+  SerializeScopeDeclarations(scope);
 }
 
 inline void BinAstSerializeVisitor::SerializeDeclarationScope(DeclarationScope* scope) {

--- a/src/parsing/preparse-data-impl.h
+++ b/src/parsing/preparse-data-impl.h
@@ -110,6 +110,16 @@ class BaseConsumedPreparseData : public ConsumedPreparseData {
       return value;
     }
 
+    base::Optional<int32_t> PeekVarint32() {
+      auto original_index = index_;
+      if (!HasRemainingBytes(kVarint32MinSize) || data_.get(index_) != kVarint32MinSize) {
+        return base::Optional<int32_t>();
+      }
+      auto result = ReadVarint32();
+      index_ = original_index;
+      return result;
+    }
+
     uint8_t ReadUint8() {
       DCHECK(has_data_);
       DCHECK(HasRemainingBytes(kUint8Size));
@@ -156,6 +166,8 @@ class BaseConsumedPreparseData : public ConsumedPreparseData {
       Zone* zone, int start_position, int* end_position, int* num_parameters,
       int* function_length, int* num_inner_functions, bool* uses_super_property,
       LanguageMode* language_mode) final;
+
+  bool IsFunctionOffsetNextSkippable(int start_position);
 
   void RestoreScopeAllocationData(DeclarationScope* scope,
                                   AstValueFactory* ast_value_factory,

--- a/src/parsing/preparse-data.cc
+++ b/src/parsing/preparse-data.cc
@@ -605,6 +605,18 @@ BaseConsumedPreparseData<Data>::GetDataForSkippableFunction(
 }
 
 template <class Data>
+bool BaseConsumedPreparseData<Data>::IsFunctionOffsetNextSkippable(int start_position) {
+  typename ByteData::ReadingScope reading_scope(this);
+  base::Optional<int32_t> start_position_from_data = scope_data_->PeekVarint32();
+  // TODO: Is it sufficient/okay to just rely on whether we can successfully read a Varint32?
+  if (start_position_from_data.has_value()) {
+    return start_position == *start_position_from_data;
+  } else {
+    return false;
+  }
+}
+
+template <class Data>
 void BaseConsumedPreparseData<Data>::RestoreScopeAllocationData(
     DeclarationScope* scope, AstValueFactory* ast_value_factory, Zone* zone) {
   DCHECK_EQ(scope->scope_type(), ScopeType::FUNCTION_SCOPE);

--- a/src/parsing/preparse-data.h
+++ b/src/parsing/preparse-data.h
@@ -300,6 +300,8 @@ class ConsumedPreparseData {
       int* function_length, int* num_inner_functions, bool* uses_super_property,
       LanguageMode* language_mode) = 0;
 
+  virtual bool IsFunctionOffsetNextSkippable(int start_position) = 0;
+
   // Restores the information needed for allocating the Scope's (and its
   // subscopes') variables.
   virtual void RestoreScopeAllocationData(DeclarationScope* scope,


### PR DESCRIPTION
…tion

This diff enables skipping inner functions during AST deserialization by
re-using the PreparseData generated by the lazy parser, which already
contains the relevant scope information needed to properly allocate
captured variables.