### PR TITLE
Unhack inner function skipping

### DIFF
--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -80,7 +80,7 @@ class BinAstDeserializer {
   Variable* CreateLocalTemporaryVariable(Scope* scope, const AstRawString* name, int index, int initializer_position, uint32_t bit_field);
   Variable* CreateLocalNonTemporaryVariable(Scope* scope, const AstRawString* name, int index, int initializer_position, uint32_t bit_field);
 
-  void HandleFunctionSkipping(Scope* scope, bool can_skip_function);
+  void HandleFunctionSkipping(Scope* scope);
 
   DeserializeResult<std::nullptr_t> DeserializeProxyVariableTable(uint8_t* serialized_ast, int offset);
   DeserializeResult<RawVariableData> DeserializeGlobalVariableReference(uint8_t* serialized_binast, int offset);
@@ -96,9 +96,9 @@ class BinAstDeserializer {
   DeserializeResult<Declaration*> DeserializeDeclaration(uint8_t* serialized_binast, int offset, Scope* scope);
   DeserializeResult<std::nullptr_t> DeserializeScopeDeclarations(uint8_t* serialized_binast, int offset, Scope* scope);
   DeserializeResult<std::nullptr_t> DeserializeScopeParameters(uint8_t* serialized_binast, int offset, DeclarationScope* scope);
-  DeserializeResult<std::nullptr_t> DeserializeCommonScopeFields(uint8_t* serialized_binast, int offset, Scope* scope, bool can_skip_function = false);
+  DeserializeResult<std::nullptr_t> DeserializeCommonScopeFields(uint8_t* serialized_binast, int offset, Scope* scope);
   DeserializeResult<Scope*> DeserializeScope(uint8_t* serialized_binast, int offset);
-  DeserializeResult<DeclarationScope*> DeserializeDeclarationScope(uint8_t* serialized_binast, int offset, bool can_skip_function);
+  DeserializeResult<DeclarationScope*> DeserializeDeclarationScope(uint8_t* serialized_binast, int offset);
 
   DeserializeResult<AstNode*> DeserializeAstNode(uint8_t* serialized_ast, int offset, bool is_toplevel = false);
   DeserializeResult<FunctionLiteral*> DeserializeFunctionLiteral(uint8_t* serialized_ast, uint32_t bit_field, int32_t position, int offset);
@@ -149,7 +149,6 @@ class BinAstDeserializer {
   uint32_t string_table_base_offset_;
   uint32_t proxy_variable_table_base_offset_;
   uint32_t global_variable_table_base_offset_;
-  bool is_root_fn_;
 };
 
 }  // namespace internal

--- a/src/parsing/binast-serialize-visitor.h
+++ b/src/parsing/binast-serialize-visitor.h
@@ -634,6 +634,9 @@ inline void BinAstSerializeVisitor::SerializeCommonScopeFields(Scope* scope) {
     scope->must_use_preparsed_scope_data_,
     scope->is_repl_mode_scope_,
     scope->deserialized_scope_uses_external_cache_,
+    // Note: If this is a DeclarationScope for a function, we need to know if the Preparser skipped this function before we visit the Declarations,
+    // which is why we store this flag here rather than in SerializeDeclarationScope.
+    scope->scope_type() == FUNCTION_SCOPE ? scope->AsDeclarationScope()->is_skipped_function() : false,
   });
   SerializeScopeDeclarations(scope);
 }

--- a/src/parsing/preparse-data-impl.h
+++ b/src/parsing/preparse-data-impl.h
@@ -110,16 +110,6 @@ class BaseConsumedPreparseData : public ConsumedPreparseData {
       return value;
     }
 
-    base::Optional<int32_t> PeekVarint32() {
-      auto original_index = index_;
-      if (!HasRemainingBytes(kVarint32MinSize) || data_.get(index_) != kVarint32MinSize) {
-        return base::Optional<int32_t>();
-      }
-      auto result = ReadVarint32();
-      index_ = original_index;
-      return result;
-    }
-
     uint8_t ReadUint8() {
       DCHECK(has_data_);
       DCHECK(HasRemainingBytes(kUint8Size));
@@ -166,8 +156,6 @@ class BaseConsumedPreparseData : public ConsumedPreparseData {
       Zone* zone, int start_position, int* end_position, int* num_parameters,
       int* function_length, int* num_inner_functions, bool* uses_super_property,
       LanguageMode* language_mode) final;
-
-  bool IsFunctionOffsetNextSkippable(int start_position);
 
   void RestoreScopeAllocationData(DeclarationScope* scope,
                                   AstValueFactory* ast_value_factory,

--- a/src/parsing/preparse-data.cc
+++ b/src/parsing/preparse-data.cc
@@ -605,18 +605,6 @@ BaseConsumedPreparseData<Data>::GetDataForSkippableFunction(
 }
 
 template <class Data>
-bool BaseConsumedPreparseData<Data>::IsFunctionOffsetNextSkippable(int start_position) {
-  typename ByteData::ReadingScope reading_scope(this);
-  base::Optional<int32_t> start_position_from_data = scope_data_->PeekVarint32();
-  // TODO: Is it sufficient/okay to just rely on whether we can successfully read a Varint32?
-  if (start_position_from_data.has_value()) {
-    return start_position == *start_position_from_data;
-  } else {
-    return false;
-  }
-}
-
-template <class Data>
 void BaseConsumedPreparseData<Data>::RestoreScopeAllocationData(
     DeclarationScope* scope, AstValueFactory* ast_value_factory, Zone* zone) {
   DCHECK_EQ(scope->scope_type(), ScopeType::FUNCTION_SCOPE);

--- a/src/parsing/preparse-data.h
+++ b/src/parsing/preparse-data.h
@@ -300,8 +300,6 @@ class ConsumedPreparseData {
       int* function_length, int* num_inner_functions, bool* uses_super_property,
       LanguageMode* language_mode) = 0;
 
-  virtual bool IsFunctionOffsetNextSkippable(int start_position) = 0;
-
   // Restores the information needed for allocating the Scope's (and its
   // subscopes') variables.
   virtual void RestoreScopeAllocationData(DeclarationScope* scope,


### PR DESCRIPTION
Previously we added a few utility functions to help us determine when we
should try to skip functions during deserialization using the ConsumedPreparseData.
This was an unreliable method, causing us to crash due to some edge cases within
the serialized PreparseData format. Ideally we would have some way to tell that
a function was skipped originally during preparsing so we wouldn't have to guess
from the contents of the PreparseData. Fortunately, this already existed in the
form of the is_skipped_function field on the DeclarationScope which we were
intentionally ignoring previously! Wow, lucky us. So now that we use that field
we can remove a bunch of hacky code from the previous implementation.