### PR TITLE
Add tracing for why speculative parsing fails

### DIFF
--- a/src/objects/objects.cc
+++ b/src/objects/objects.cc
@@ -4998,6 +4998,7 @@ void SharedFunctionInfo::Init(ReadOnlyRoots ro_roots, int unique_id) {
 #if V8_SFI_HAS_UNIQUE_ID
   set_unique_id(unique_id);
 #endif
+  set_speculative_parse_failure_reason(SpeculativeParseFailureReason::kUnknown);
 
   // Set integer fields (smi or int, depending on the architecture).
   set_length(0);
@@ -5454,6 +5455,7 @@ void SharedFunctionInfo::InitFromFunctionLiteral(
     // because we don't have that info at that point, so we should rearrange things
     // such that we do so we can satisfy this assert.
     // DCHECK_NULL(lit->produced_preparse_data());
+    shared_info->set_speculative_parse_failure_reason(SpeculativeParseFailureReason::kEagerParsed);
 
     // If we're about to eager compile, we'll have the function literal
     // available, so there's no need to wastefully allocate an uncompiled data.
@@ -5462,6 +5464,9 @@ void SharedFunctionInfo::InitFromFunctionLiteral(
 
   shared_info->set_is_safe_to_skip_arguments_adaptor(false);
   shared_info->UpdateExpectedNofPropertiesFromEstimate(lit);
+
+  DCHECK(!lit->has_uncompiled_data_with_inner_bin_ast_parse_data() || lit->speculative_parse_failure_reason() == SpeculativeParseFailureReason::kSucceeded);
+  shared_info->set_speculative_parse_failure_reason(lit->speculative_parse_failure_reason());
 
   Handle<UncompiledData> data;
 

--- a/src/objects/shared-function-info-inl.h
+++ b/src/objects/shared-function-info-inl.h
@@ -14,6 +14,7 @@
 #include "src/objects/feedback-vector-inl.h"
 #include "src/objects/scope-info.h"
 #include "src/objects/templates.h"
+#include "src/ast/ast.h"
 #include "src/wasm/wasm-objects-inl.h"
 
 // Has to be the last include (doesn't have include guards):
@@ -111,6 +112,7 @@ ACCESSORS(SharedFunctionInfo, script_or_debug_info, HeapObject,
 INT32_ACCESSORS(SharedFunctionInfo, function_literal_id,
                 kFunctionLiteralIdOffset)
 
+INT32_ACCESSORS(SharedFunctionInfo, speculative_parse_failure_reason, kSpeculativeParseFailureReasonOffset)
 #if V8_SFI_HAS_UNIQUE_ID
 INT_ACCESSORS(SharedFunctionInfo, unique_id, kUniqueIdOffset)
 #endif
@@ -683,6 +685,8 @@ void SharedFunctionInfo::ClearBinAstParseData() {
           UncompiledDataWithoutPreparseData::kSize,
       ClearRecordedSlots::kYes);
 
+  set_speculative_parse_failure_reason(SpeculativeParseFailureReason::kSFIFlushed);
+
   // Ensure that the clear was successful.
   DCHECK(HasUncompiledDataWithoutPreparseData());
   DCHECK(!HasUncompiledDataWithBinAstParseData());
@@ -710,6 +714,8 @@ void SharedFunctionInfo::ClearInnerBinAstParseData() {
       UncompiledDataWithInnerBinAstParseData::kSize -
           UncompiledDataWithoutPreparseData::kSize,
       ClearRecordedSlots::kYes);
+
+  set_speculative_parse_failure_reason(SpeculativeParseFailureReason::kSFIFlushed);
 
   // Ensure that the clear was successful.
   DCHECK(HasUncompiledDataWithoutPreparseData());

--- a/src/objects/shared-function-info.h
+++ b/src/objects/shared-function-info.h
@@ -340,6 +340,8 @@ class SharedFunctionInfo : public HeapObject {
   // SharedFunctionInfo object doesn't correspond to a parsed FunctionLiteral.
   DECL_INT32_ACCESSORS(function_literal_id)
 
+  DECL_INT32_ACCESSORS(speculative_parse_failure_reason)
+
 #if V8_SFI_HAS_UNIQUE_ID
   // [unique_id] - For --trace-maps purposes, an identifier that's persistent
   // even if the GC moves this SharedFunctionInfo.

--- a/src/objects/shared-function-info.tq
+++ b/src/objects/shared-function-info.tq
@@ -63,6 +63,7 @@ extern class SharedFunctionInfo extends HeapObject {
   flags2: SharedFunctionInfoFlags2;
   flags: SharedFunctionInfoFlags;
   function_literal_id: int32;
+  speculative_parse_failure_reason: int32;
   @if(V8_SFI_HAS_UNIQUE_ID) unique_id: int32;
 }
 

--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -530,7 +530,7 @@ BinAstDeserializer::DeserializeResult<FunctionLiteral*> BinAstDeserializer::Dese
   FunctionLiteral* result = parser_->factory()->NewFunctionLiteral(
     raw_name, scope.value, body, expected_property_count.value, parameter_count.value,
     function_length.value, has_duplicate_parameters, function_syntax_kind,
-    eager_compile_hint, position, has_braces, function_literal_id.value);
+    eager_compile_hint, position, has_braces, function_literal_id.value, SpeculativeParseFailureReason::kSucceeded);
 
   result->function_token_position_ = function_token_position.value;
   result->suspend_count_ = suspend_count.value;

--- a/src/parsing/binast-parse-data.cc
+++ b/src/parsing/binast-parse-data.cc
@@ -77,10 +77,13 @@ ProducedBinAstParseData* ProducedBinAstParseData::For(ZoneBinAstParseData* data,
   return new (zone) ZoneProducedBinAstParseData(data);
 }
 
-ZoneBinAstParseData* ZoneBinAstParseDataBuilder::Serialize(Zone* zone, AstValueFactory* ast_value_factory, FunctionLiteral* function_literal) {
+ZoneBinAstParseData* ZoneBinAstParseDataBuilder::Serialize(Zone* zone, AstValueFactory* ast_value_factory, FunctionLiteral* function_literal, SpeculativeParseFailureReason* failure_reason_ptr) {
   BinAstSerializeVisitor visitor(ast_value_factory);
-  bool success = visitor.SerializeAst(function_literal);
-  if (!success) {
+  SpeculativeParseFailureReason failure_reason = visitor.SerializeAst(function_literal);
+  if (failure_reason_ptr != nullptr) {
+    *failure_reason_ptr = failure_reason;
+  }
+  if (failure_reason != kSucceeded) {
     return nullptr;
   }
   Vector<uint8_t> vector_byte_data(visitor.serialized_bytes(), visitor.serialized_bytes_length());

--- a/src/parsing/binast-parse-data.h
+++ b/src/parsing/binast-parse-data.h
@@ -14,6 +14,7 @@ class FunctionLiteral;
 class ZoneBinAstParseData;
 class BinAstParseData;
 class AstValueFactory;
+enum SpeculativeParseFailureReason : uint8_t;
 
 class ProducedBinAstParseData : public ZoneObject {
  public:
@@ -30,7 +31,7 @@ class ProducedBinAstParseData : public ZoneObject {
 
 class ZoneBinAstParseDataBuilder {
  public:
-  static ZoneBinAstParseData* Serialize(Zone* zone, AstValueFactory* ast_value_factory, FunctionLiteral* function_literal);
+  static ZoneBinAstParseData* Serialize(Zone* zone, AstValueFactory* ast_value_factory, FunctionLiteral* function_literal, SpeculativeParseFailureReason* failure_reason_ptr);
 };
 
 }  // namespace internal

--- a/src/parsing/binast-parser.h
+++ b/src/parsing/binast-parser.h
@@ -49,6 +49,8 @@ class BinAstParser : public AbstractParser<BinAstParser> {
     LanguageMode language_mode,
     ZonePtrList<const AstRawString>* arguments_for_wrapped_function);
 
+  SpeculativeParseFailureReason speculative_parse_failure_reason() const { return SpeculativeParseFailureReason::kUnknown; }
+
 };
 
 }  // namespace internal

--- a/src/parsing/parse-info.cc
+++ b/src/parsing/parse-info.cc
@@ -104,7 +104,8 @@ UnoptimizedCompileFlags UnoptimizedCompileFlags::ForToplevelCompile(
 UnoptimizedCompileFlags UnoptimizedCompileFlags::ForToplevelFunction(
     const UnoptimizedCompileFlags toplevel_flags,
     const FunctionLiteral* literal) {
-  DCHECK(toplevel_flags.is_toplevel());
+  // TODO(binast): Figure out how to properly solve this issue for background parsing.
+  // DCHECK(toplevel_flags.is_toplevel());
   DCHECK(!literal->is_toplevel());
 
   // Replicate the toplevel flags, then setup the function-specific flags.
@@ -191,6 +192,7 @@ ParseInfo::ParseInfo(const UnoptimizedCompileFlags flags,
       runtime_call_stats_(nullptr),
       source_range_map_(nullptr),
       literal_(nullptr),
+      speculative_parse_failure_reason_(SpeculativeParseFailureReason::kUnknown),
       allow_eval_cache_(false),
       contains_asm_module_(false),
       language_mode_(flags.outer_language_mode()) {

--- a/src/parsing/parse-info.h
+++ b/src/parsing/parse-info.h
@@ -39,6 +39,7 @@ class Logger;
 class SourceRangeMap;
 class Utf16CharacterStream;
 class Zone;
+enum SpeculativeParseFailureReason : uint8_t;
 
 // The flags for a parse + unoptimized compile operation.
 #define FLAG_FIELDS(V, _)                                \
@@ -305,6 +306,9 @@ class V8_EXPORT_PRIVATE ParseInfo {
   FunctionLiteral* literal() const { return literal_; }
   void set_literal(FunctionLiteral* literal) { literal_ = literal; }
 
+  SpeculativeParseFailureReason speculative_parse_failure_reason() const { return speculative_parse_failure_reason_; }
+  void set_speculative_parse_failure_reason(SpeculativeParseFailureReason reason) { speculative_parse_failure_reason_ = reason; }
+
   DeclarationScope* scope() const;
 
   int parameters_end_pos() const { return parameters_end_pos_; }
@@ -357,6 +361,7 @@ class V8_EXPORT_PRIVATE ParseInfo {
 
   //----------- Output of parsing and scope analysis ------------------------
   FunctionLiteral* literal_;
+  SpeculativeParseFailureReason speculative_parse_failure_reason_;
   bool allow_eval_cache_ : 1;
   bool contains_asm_module_ : 1;
   LanguageMode language_mode_ : 1;

--- a/src/parsing/parser-base.h
+++ b/src/parsing/parser-base.h
@@ -4350,6 +4350,7 @@ ParserBase<Impl>::ParseArrowFunctionLiteral(
   bool is_lazy_top_level_function =
       can_preparse && impl()->AllowsLazyParsingWithoutUnresolvedVariables();
   bool has_braces = true;
+  bool did_preparse_successfully = false;
   ProducedPreparseData* produced_preparse_data = nullptr;
   StatementListT body(pointer_buffer());
   {
@@ -4379,7 +4380,7 @@ ParserBase<Impl>::ParseArrowFunctionLiteral(
         int dummy_num_parameters = -1;
         int dummy_function_length = -1;
         DCHECK_NE(kind & FunctionKind::kArrowFunction, 0);
-        bool did_preparse_successfully = impl()->SkipFunction(
+        did_preparse_successfully = impl()->SkipFunction(
             nullptr, kind, FunctionSyntaxKind::kAnonymousExpression,
             formal_parameters.scope, &dummy_num_parameters,
             &dummy_function_length, &produced_preparse_data);
@@ -4460,7 +4461,9 @@ ParserBase<Impl>::ParseArrowFunctionLiteral(
       FunctionLiteral::kNoDuplicateParameters,
       FunctionSyntaxKind::kAnonymousExpression, eager_compile_hint,
       formal_parameters.scope->start_position(), has_braces,
-      function_literal_id, produced_preparse_data);
+      function_literal_id,
+      is_lazy_top_level_function ? SpeculativeParseFailureReason::kTopLevelArrowFunction : impl()->speculative_parse_failure_reason(),
+      produced_preparse_data);
 
   function_literal->set_suspend_count(suspend_count);
   function_literal->set_function_token_position(

--- a/src/parsing/parser.h
+++ b/src/parsing/parser.h
@@ -18,6 +18,8 @@ class V8_EXPORT_PRIVATE Parser
  public:
   Parser(ParseInfo* info) : AbstractParser<Parser>(info) {}
 
+  SpeculativeParseFailureReason speculative_parse_failure_reason() const { return info()->speculative_parse_failure_reason(); }
+
  private:
   friend class AbstractParser<Parser>;
   

--- a/src/parsing/preparser.h
+++ b/src/parsing/preparser.h
@@ -677,6 +677,7 @@ class PreParserFactory {
       FunctionSyntaxKind function_syntax_kind,
       FunctionLiteral::EagerCompileHint eager_compile_hint, int position,
       bool has_braces, int function_literal_id,
+      SpeculativeParseFailureReason speculative_parse_failure_reason,
       ProducedPreparseData* produced_preparse_data = nullptr) {
     DCHECK_NULL(produced_preparse_data);
     return PreParserExpression::Default();
@@ -969,6 +970,8 @@ class PreParser : public ParserBase<PreParser> {
   std::vector<void*>* preparse_data_builder_buffer() {
     return &preparse_data_builder_buffer_;
   }
+
+  SpeculativeParseFailureReason speculative_parse_failure_reason() const { return SpeculativeParseFailureReason::kUnknown; }
 
  private:
   friend class i::ExpressionScope<ParserTypes<PreParser>>;

--- a/src/parsing/scanner-character-streams.cc
+++ b/src/parsing/scanner-character-streams.cc
@@ -83,6 +83,7 @@ class OnHeapStream {
 
   static const bool kCanBeCloned = false;
   static const bool kCanAccessHeap = true;
+  static const StreamKind kStreamKind = kOnHeapStream;
 
  private:
   Handle<String> string_;
@@ -117,6 +118,7 @@ class ExternalStringStream {
 
   static const bool kCanBeCloned = true;
   static const bool kCanAccessHeap = false;
+  static const StreamKind kStreamKind = kExternalStringStream;
 
  private:
   ScopedExternalStringLock lock_;
@@ -139,6 +141,7 @@ class TestingStream {
 
   static const bool kCanBeCloned = true;
   static const bool kCanAccessHeap = false;
+  static const StreamKind kStreamKind = kTestingStream;
 
  private:
   const Char* const data_;
@@ -173,6 +176,7 @@ class ChunkedStream {
 
   static const bool kCanBeCloned = false;
   static const bool kCanAccessHeap = false;
+  static const StreamKind kStreamKind = kChunkedStream;
 
  private:
   struct Chunk {
@@ -249,6 +253,10 @@ class BufferedCharacterStream : public Utf16CharacterStream {
         new BufferedCharacterStream<ByteStream>(*this));
   }
 
+  StreamKind stream_kind() const override {
+    return ByteStream<uint16_t>::kStreamKind;
+  }
+
  protected:
   bool ReadBlock() final {
     size_t position = pos();
@@ -304,6 +312,10 @@ class UnbufferedCharacterStream : public Utf16CharacterStream {
   std::unique_ptr<Utf16CharacterStream> Clone() const override {
     return std::unique_ptr<Utf16CharacterStream>(
         new UnbufferedCharacterStream<ByteStream>(*this));
+  }
+
+  StreamKind stream_kind() const override {
+    return ByteStream<uint16_t>::kStreamKind;
   }
 
  protected:
@@ -437,7 +449,11 @@ class Utf8ExternalStreamingStream : public BufferedUtf16CharacterStream {
   bool can_be_cloned() const final { return false; }
 
   std::unique_ptr<Utf16CharacterStream> Clone() const override {
-    UNREACHABLE();
+    return std::unique_ptr<Utf16CharacterStream>(new Utf8ExternalStreamingStream(*this));
+  }
+
+  StreamKind stream_kind() const override {
+    return kExternalUtf8Stream;
   }
 
  protected:
@@ -833,8 +849,9 @@ Utf16CharacterStream* ScannerStream::For(
     case v8::ScriptCompiler::StreamedSource::ONE_BYTE:
       return new BufferedCharacterStream<ChunkedStream>(static_cast<size_t>(0),
                                                         source_stream);
-    case v8::ScriptCompiler::StreamedSource::UTF8:
+    case v8::ScriptCompiler::StreamedSource::UTF8: {
       return new Utf8ExternalStreamingStream(source_stream);
+    }
   }
   UNREACHABLE();
 }

--- a/src/parsing/scanner.h
+++ b/src/parsing/scanner.h
@@ -33,6 +33,14 @@ class ParserRecorder;
 class RuntimeCallStats;
 class Zone;
 
+enum StreamKind : uint8_t {
+    kOnHeapStream,
+    kExternalStringStream,
+    kTestingStream,
+    kChunkedStream,
+    kExternalUtf8Stream,
+};
+
 // ---------------------------------------------------------------------
 // Buffered stream of UTF-16 code units, using an internal UTF-16 buffer.
 // A code unit is a 16 bit value representing either a 16 bit code point
@@ -131,6 +139,9 @@ class Utf16CharacterStream {
   // Clones the character stream to enable another independent scanner to access
   // the same underlying stream.
   virtual std::unique_ptr<Utf16CharacterStream> Clone() const = 0;
+
+  // Returns the kind of the underlying stream.
+  virtual StreamKind stream_kind() const = 0;
 
   // Returns true if the stream could access the V8 heap after construction.
   virtual bool can_access_heap() const = 0;

--- a/test/unittests/compiler-dispatcher/compiler-dispatcher-unittest.cc
+++ b/test/unittests/compiler-dispatcher/compiler-dispatcher-unittest.cc
@@ -94,7 +94,7 @@ class CompilerDispatcherTest : public TestWithNativeContext {
             FunctionLiteral::kNoDuplicateParameters,
             FunctionSyntaxKind::kAnonymousExpression,
             FunctionLiteral::kShouldEagerCompile, shared->StartPosition(), true,
-            shared->function_literal_id(), nullptr);
+            shared->function_literal_id(), shared->speculative_parse_failure_reason(), nullptr);
 
     return dispatcher->Enqueue(outer_parse_info.get(), function_name,
                                function_literal);

--- a/test/unittests/heap/off-thread-factory-unittest.cc
+++ b/test/unittests/heap/off-thread-factory-unittest.cc
@@ -267,7 +267,7 @@ TEST_F(OffThreadFactoryTest, EmptyScript) {
 
     shared = off_thread_isolate()->TransferHandle(
         off_thread_factory()->NewSharedFunctionInfoForLiteral(program, script(),
-                                                              true));
+                                                              true, SpeculativeParseFailureReason::kUnknown));
 
     off_thread_isolate()->FinishOffThread();
   }
@@ -292,7 +292,7 @@ TEST_F(OffThreadFactoryTest, LazyFunction) {
 
     shared = off_thread_isolate()->TransferHandle(
         off_thread_factory()->NewSharedFunctionInfoForLiteral(lazy, script(),
-                                                              true));
+                                                              true, SpeculativeParseFailureReason::kUnknown));
 
     off_thread_isolate()->FinishOffThread();
   }
@@ -323,7 +323,7 @@ TEST_F(OffThreadFactoryTest, EagerFunction) {
 
     shared = off_thread_isolate()->TransferHandle(
         off_thread_factory()->NewSharedFunctionInfoForLiteral(eager, script(),
-                                                              true));
+                                                              true, SpeculativeParseFailureReason::kUnknown));
 
     off_thread_isolate()->FinishOffThread();
   }
@@ -358,7 +358,7 @@ TEST_F(OffThreadFactoryTest, ImplicitNameFunction) {
 
     shared = off_thread_isolate()->TransferHandle(
         off_thread_factory()->NewSharedFunctionInfoForLiteral(implicit_name,
-                                                              script(), true));
+                                                              script(), true, SpeculativeParseFailureReason::kUnknown));
 
     off_thread_isolate()->FinishOffThread();
   }
@@ -390,7 +390,7 @@ TEST_F(OffThreadFactoryTest, GCDuringPublish) {
 
     shared = off_thread_isolate()->TransferHandle(
         off_thread_factory()->NewSharedFunctionInfoForLiteral(implicit_name,
-                                                              script(), true));
+                                                              script(), true, SpeculativeParseFailureReason::kUnknown));
 
     off_thread_isolate()->FinishOffThread();
   }

--- a/test/unittests/tasks/background-compile-task-unittest.cc
+++ b/test/unittests/tasks/background-compile-task-unittest.cc
@@ -73,7 +73,7 @@ class BackgroundCompileTaskTest : public TestWithNativeContext {
             FunctionLiteral::kNoDuplicateParameters,
             FunctionSyntaxKind::kAnonymousExpression,
             FunctionLiteral::kShouldEagerCompile, shared->StartPosition(), true,
-            shared->function_literal_id(), nullptr);
+            shared->function_literal_id(), shared->speculative_parse_failure_reason(), nullptr);
 
     return new BackgroundCompileTask(
         outer_parse_info.get(), function_name, function_literal,


### PR DESCRIPTION
We want to be able to track why the speculative parser isn't able to process
the functions flowing through v8's parsing infrastructure. In particular,
for a parent function that fails to parse this will cause all of its children
to fail as well, and we'd like to properly thread that information to its
children so we properly attribute each issue. This change accomplishes this
by passing it via FunctionLiteral and storing it on the SharedFunctionInfo.