### PR TITLE
Use single vector with ScopedPtrList in deserializer

### DIFF
--- a/src/parsing/binast-deserializer-inl.h
+++ b/src/parsing/binast-deserializer-inl.h
@@ -729,9 +729,8 @@ inline BinAstDeserializer::DeserializeResult<Call*> BinAstDeserializer::Deserial
   auto params_count = DeserializeInt32(serialized_binast, offset);
   offset = params_count.new_offset;
 
-  std::vector<void*> pointer_buffer;
-  pointer_buffer.reserve(params_count.value);
-  ScopedPtrList<Expression> params(&pointer_buffer);
+  ScopedPtrList<Expression> params(pointer_buffer());
+  params.Reserve(params_count.value);
   for (int i = 0; i < params_count.value; ++i) {
     auto param = DeserializeAstNode(serialized_binast, offset);
     offset = param.new_offset;
@@ -752,9 +751,8 @@ inline BinAstDeserializer::DeserializeResult<CallNew*> BinAstDeserializer::Deser
   auto params_count = DeserializeInt32(serialized_binast, offset);
   offset = params_count.new_offset;
 
-  std::vector<void*> pointer_buffer;
-  pointer_buffer.reserve(params_count.value);
-  ScopedPtrList<Expression> params(&pointer_buffer);
+  ScopedPtrList<Expression> params(pointer_buffer());
+  params.Reserve(params_count.value);
   for (int i = 0; i < params_count.value; ++i) {
     auto param = DeserializeAstNode(serialized_binast, offset);
     offset = param.new_offset;
@@ -797,9 +795,8 @@ inline BinAstDeserializer::DeserializeResult<Block*> BinAstDeserializer::Deseria
   auto statement_count = DeserializeInt32(serialized_binast, offset);
   offset = statement_count.new_offset;
 
-  std::vector<void*> pointer_buffer;
-  pointer_buffer.reserve(statement_count.value);
-  ScopedPtrList<Statement> statements(&pointer_buffer);
+  ScopedPtrList<Statement> statements(pointer_buffer());
+  statements.Reserve(statement_count.value);
   if (scope != nullptr) {
     Parser::BlockState block_state(&parser_->scope_, scope);
     for (int i = 0; i < statement_count.value; ++i) {

--- a/src/parsing/binast-deserializer.cc
+++ b/src/parsing/binast-deserializer.cc
@@ -502,9 +502,8 @@ BinAstDeserializer::DeserializeResult<FunctionLiteral*> BinAstDeserializer::Dese
   auto num_statements = DeserializeInt32(serialized_binast, offset);
   offset = num_statements.new_offset;
 
-  std::vector<void*> pointer_buffer;
-  pointer_buffer.reserve(num_statements.value);
-  ScopedPtrList<Statement> body(&pointer_buffer);
+  ScopedPtrList<Statement> body(pointer_buffer());
+  body.Reserve(num_statements.value);
   if (!scope.value->is_skipped_function()) {
     // Warning: leaky separation of concerns. We need to clear the Scope's unresolved_list_ so
     // that the VariableProxy nodes we encounter during the deserialization of the
@@ -560,8 +559,8 @@ BinAstDeserializer::DeserializeResult<ObjectLiteral*> BinAstDeserializer::Deseri
   auto boilerplate_properties = DeserializeInt32(serialized_binast, offset);
   offset = boilerplate_properties.new_offset;
 
-  std::vector<void*> pointer_buffer;
-  ScopedPtrList<ObjectLiteral::Property> properties(&pointer_buffer);
+  ScopedPtrList<ObjectLiteral::Property> properties(pointer_buffer());
+  properties.Reserve(properties_length.value);
 
   for (int i = 0; i < properties_length.value; i++) {
     auto key = DeserializeAstNode(serialized_binast, offset);
@@ -608,9 +607,8 @@ BinAstDeserializer::DeserializeArrayLiteral(uint8_t* serialized_binast,
 
   DCHECK(first_spread_index.value == -1);
 
-  std::vector<void*> pointer_buffer;
-  pointer_buffer.reserve(array_length.value);
-  ScopedPtrList<Expression> values(&pointer_buffer);
+  ScopedPtrList<Expression> values(pointer_buffer());
+  values.Reserve(array_length.value);
 
   for (int i = 0; i < array_length.value; i++) {
     auto value = DeserializeAstNode(serialized_binast, offset);
@@ -759,9 +757,8 @@ BinAstDeserializer::DeserializeSwitchStatement(uint8_t* serialized_binast,
     auto statements_length = DeserializeInt32(serialized_binast, offset);
     offset = statements_length.new_offset;
 
-    std::vector<void*> pointer_buffer;
-    pointer_buffer.reserve(statements_length.value);
-    ScopedPtrList<Statement> statements(&pointer_buffer);
+    ScopedPtrList<Statement> statements(pointer_buffer());
+    statements.Reserve(statements_length.value);
 
     for (int i = 0; i < statements_length.value; i++) {
       auto statement = DeserializeAstNode(serialized_binast, offset);

--- a/src/parsing/binast-deserializer.h
+++ b/src/parsing/binast-deserializer.h
@@ -46,6 +46,7 @@ class BinAstDeserializer {
   };
 
   Zone* zone();
+  std::vector<void*>* pointer_buffer() { return &pointer_buffer_; }
   static bool UseCompression() { return false; }
 
   AstNode* DeserializeCompressedAst(base::Optional<uint32_t> start_offset,
@@ -144,6 +145,7 @@ class BinAstDeserializer {
   Handle<ByteArray> parse_data_;
   MaybeHandle<PreparseData> preparse_data_;
   std::unique_ptr<ConsumedPreparseData> consumed_preparse_data_;
+  std::vector<void*> pointer_buffer_;
   std::vector<const AstRawString*> strings_;
   std::vector<Variable*> variables_;
   std::unordered_map<uint32_t, AstNode*> nodes_by_offset_;

--- a/src/utils/scoped-list.h
+++ b/src/utils/scoped-list.h
@@ -87,6 +87,10 @@ class V8_NODISCARD ScopedList final {
     end_ += list.length();
   }
 
+  void Reserve(size_t length) {
+    buffer_.reserve(buffer_.size() + length);
+  }
+
   using iterator = T*;
   using const_iterator = const T*;
 


### PR DESCRIPTION
The normal parser also uses this optimization to reduce the amount of
allocation necessary when gathering AST nodes into a list to pass around.